### PR TITLE
cache column offsets

### DIFF
--- a/Lumina/Excel/ExcelSheetImpl.cs
+++ b/Lumina/Excel/ExcelSheetImpl.cs
@@ -54,6 +54,20 @@ namespace Lumina.Excel
 
         public ExcelColumnDefinition[] Columns => HeaderFile.ColumnDefinitions;
 
+        private Dictionary<ushort, ExcelColumnDefinition> _columnsByOffset;
+        public Dictionary<ushort, ExcelColumnDefinition> ColumnsByOffset
+        {
+            get
+            {
+                if( _columnsByOffset == null )
+                {
+                    _columnsByOffset = Columns.GroupBy( p => p.Offset ).ToDictionary( c => c.Key, c => c.First() );
+                }
+                return _columnsByOffset;
+            }
+        }
+
+
         public ExcelDataPagination[] DataPagination => HeaderFile.DataPages;
 
         public Language[] Languages => HeaderFile.Languages;

--- a/Lumina/Excel/RowParser.cs
+++ b/Lumina/Excel/RowParser.cs
@@ -239,7 +239,7 @@ namespace Lumina.Excel
             return count;
         }
 
-        public T ReadOffset< T >( int offset, byte bit = 0 )
+        public T ReadOffset< T >( ushort offset, byte bit = 0 )
         {
             Stream.Position = _RowOffset + offset;
 
@@ -251,8 +251,7 @@ namespace Lumina.Excel
                 return ReadField< T >( flag );
             }
 
-            var col = _Sheet.Columns.First( c => c.Offset == offset );
-            return ReadField< T >( col.Type );
+            return ReadField< T >( _Sheet.ColumnsByOffset[offset].Type );
         }
 
         public T ReadOffset< T >( int offset, ExcelColumnDataType type )


### PR DESCRIPTION
reduces time required to iterate over all quest records from ~43s to sub 1s on my machine. 