### PR TITLE
Add rudimentary support for PCB files

### DIFF
--- a/src/Lumina/Data/Files/Pcb/PcbListFile.cs
+++ b/src/Lumina/Data/Files/Pcb/PcbListFile.cs
@@ -1,0 +1,67 @@
+using System.IO;
+using Lumina.Data.Attributes;
+using Lumina.Data.Parsing;
+
+namespace Lumina.Data.Files.Pcb
+{
+    [FileExtension( "list.pcb" )]
+    public class PcbListFile : FileResource
+    {
+        public struct PcbNodeList {
+            public Common.BoundingBox BoundingBox;
+            public ListNode[] Children;
+            
+            public static PcbNodeList Read( BinaryReader reader )
+            {
+                var nodeList = new PcbNodeList
+                {
+                    Children = new ListNode[reader.ReadUInt32()],
+                    BoundingBox = Common.BoundingBox.Read( reader )
+                };
+
+                // Padding
+                reader.BaseStream.Position += 4;
+                
+                for( var i = 0; i < nodeList.Children.Length; i++ )
+                {
+                    nodeList.Children[ i ] = ListNode.Read( reader );
+                }
+
+                return nodeList;
+            }
+        }
+        
+        public struct ListNode
+        {
+            public uint Id;
+            public Common.BoundingBox BoundingBox;
+
+            public static ListNode Read( BinaryReader reader )
+            {
+                var node = new ListNode
+                {
+                    Id = reader.ReadUInt32(),
+                    BoundingBox = Common.BoundingBox.Read( reader )
+                };
+
+                // Padding
+                reader.BaseStream.Position += 4;
+
+                return node;
+            }
+        }
+
+        public PcbNodeList Nodes;
+
+        public override void LoadFile()
+        {
+            var streamStart = Reader.BaseStream.Position;
+            var isList = Reader.ReadUInt32() != 0;
+            Reader.BaseStream.Position = streamStart;
+
+            if( !isList ) return;
+            
+            Nodes = PcbNodeList.Read( Reader );
+        }
+    }
+}

--- a/src/Lumina/Data/Files/Pcb/PcbListFile.cs
+++ b/src/Lumina/Data/Files/Pcb/PcbListFile.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Lumina.Data.Attributes;
 using Lumina.Data.Parsing;
@@ -59,7 +60,9 @@ namespace Lumina.Data.Files.Pcb
             var isList = Reader.ReadUInt32() != 0;
             Reader.BaseStream.Position = streamStart;
 
-            if( !isList ) return;
+            if( !isList ) {
+                throw new InvalidOperationException( "Error parsing pcb list" );
+            }
             
             Nodes = PcbNodeList.Read( Reader );
         }

--- a/src/Lumina/Data/Files/Pcb/PcbResourceFile.cs
+++ b/src/Lumina/Data/Files/Pcb/PcbResourceFile.cs
@@ -148,8 +148,11 @@ namespace Lumina.Data.Files.Pcb
             var isList = Reader.ReadUInt32() != 0;
             Reader.BaseStream.Position = streamStart;
 
-            if( isList ) return;
-            
+            if( isList )
+            {
+                throw new InvalidOperationException( "Error parsing pcb file" );
+            }
+
             Nodes = PcbResourceHeader.Read( Reader );
         }
 

--- a/src/Lumina/Data/Files/Pcb/PcbResourceFile.cs
+++ b/src/Lumina/Data/Files/Pcb/PcbResourceFile.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Lumina.Data.Attributes;
+using Lumina.Data.Parsing;
+
+namespace Lumina.Data.Files.Pcb
+{
+    [FileExtension( ".pcb" )]
+    public class PcbResourceFile : FileResource
+    {
+        public struct PcbResourceHeader {
+            public uint Magic;
+            public uint Version;
+            public uint TotalNodes;
+            public uint TotalPolygons;
+
+            public List<ResourceNode> Children;
+            
+            public static PcbResourceHeader Read( BinaryReader reader )
+            {
+                var header = new PcbResourceHeader
+                {
+                    Magic = reader.ReadUInt32(),
+                    Version = reader.ReadUInt32(),
+                    TotalNodes = reader.ReadUInt32(),
+                    TotalPolygons = reader.ReadUInt32()
+                };
+
+                if( header.TotalNodes == 0 )
+                    return header;
+                
+                header.Children = new List<ResourceNode>();
+
+                var totalNodesRead = 0;
+                while( totalNodesRead <= header.TotalNodes )
+                {
+                    header.Children.Add( ResourceNode.ReadWithCount( reader, out var nodesRead ) );
+                    totalNodesRead += nodesRead;
+                }
+                
+                return header;
+            }
+        }
+        
+        public struct ResourceNode
+        {
+            public uint Magic;
+            public uint Version;
+            public uint HeaderSkip;
+            public uint GroupLength;
+            public Common.BoundingBox BoundingBox;
+
+            public Common.Vector3[] Vertices;
+            public Polygon[] Polygons;
+
+            public List<ResourceNode> Children;
+            
+            public static ResourceNode ReadWithCount( BinaryReader reader, out int totalNodesRead )
+            {
+                totalNodesRead = 1;
+
+                var initialPosition = reader.BaseStream.Position;
+                
+                var header = new ResourceNode
+                {
+                    Magic = reader.ReadUInt32(),
+                    Version = reader.ReadUInt32(),
+                    HeaderSkip = reader.ReadUInt32(),
+                    GroupLength = reader.ReadUInt32(),
+                    BoundingBox = Common.BoundingBox.Read( reader )
+                };
+                var numVertFloat16 = reader.ReadUInt16();
+                header.Polygons = new Polygon[reader.ReadUInt16()];
+                var numVertFloat32 = reader.ReadUInt16();
+                
+                header.Vertices = new Common.Vector3[numVertFloat16 + numVertFloat32];
+
+                // Padding
+                reader.BaseStream.Position += 2;
+                
+                
+                if( header.GroupLength != 0 )
+                {
+                    header.Children = new List<ResourceNode>();
+
+                    var finalPosition = initialPosition + header.GroupLength;
+                    while( reader.BaseStream.Position + header.HeaderSkip < finalPosition )
+                    {
+                        header.Children.Add( ResourceNode.ReadWithCount( reader, out var nodesRead ) );
+                        totalNodesRead += nodesRead;
+                    }
+
+                    reader.BaseStream.Position = finalPosition;
+                }
+
+                for( var i = 0; i < numVertFloat32; i++ )
+                {
+                    header.Vertices[ i ] = Common.Vector3.Read( reader );
+                }
+                
+                for( var i = numVertFloat32; i < numVertFloat32 + numVertFloat16; i++ )
+                {
+                    header.Vertices[ i ] = Common.Vector3.Read16( reader );
+                }
+
+                for( var i = 0; i < header.Polygons.Length; i++ )
+                {
+                    header.Polygons[i] = Polygon.Read( reader );
+                }
+                
+                
+                return header;
+            }
+        }
+        
+        public struct Polygon
+        {
+            public byte[] VertexIndex;
+            public ushort Unknown;
+            
+            public static Polygon Read( BinaryReader reader )
+            {
+                var polygon = new Polygon
+                {
+                    VertexIndex = reader.ReadBytes( 3 ),
+                };
+
+                // Padding
+                reader.BaseStream.Position += 2;
+
+                polygon.Unknown = reader.ReadUInt16();
+
+                // Padding
+                reader.BaseStream.Position += 5;
+
+                return polygon;
+            }
+        }
+
+        public PcbResourceHeader Nodes;
+
+        public override void LoadFile()
+        {
+            var streamStart = Reader.BaseStream.Position;
+            var isList = Reader.ReadUInt32() != 0;
+            Reader.BaseStream.Position = streamStart;
+
+            if( isList ) return;
+            
+            Nodes = PcbResourceHeader.Read( Reader );
+        }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder($"Total Nodes: {Nodes.TotalNodes}; Total Polygons: {Nodes.TotalPolygons}.");
+            
+            foreach (var n in Nodes.Children)
+            {
+                Stringify( sb, n, "" );
+            }
+
+            return sb.ToString();
+        }
+
+        private static void Stringify( StringBuilder sb, ResourceNode r, string tabs )
+        {
+            sb.AppendLine( $"{tabs}Bounding Box: " +
+                           $"({r.BoundingBox.Min.X}, {r.BoundingBox.Min.Y}, {r.BoundingBox.Min.Z}) => " +
+                           $"({r.BoundingBox.Max.X}, {r.BoundingBox.Max.Y}, {r.BoundingBox.Max.Z})" );
+            
+            if( r.Polygons.Length > 0 )
+            {
+                sb.AppendLine( $"{tabs}Polygons:" );
+                foreach( var p in r.Polygons )
+                {
+                    sb.AppendLine(
+                        $"{tabs}" +
+                        $"({r.Vertices[ p.VertexIndex[ 0 ] ].X}, {r.Vertices[ p.VertexIndex[ 0 ] ].Y}, {r.Vertices[ p.VertexIndex[ 0 ] ].Z}), " +
+                        $"({r.Vertices[ p.VertexIndex[ 1 ] ].X}, {r.Vertices[ p.VertexIndex[ 1 ] ].Y}, {r.Vertices[ p.VertexIndex[ 1 ] ].Z}), " +
+                        $"({r.Vertices[ p.VertexIndex[ 2 ] ].X}, {r.Vertices[ p.VertexIndex[ 2 ] ].Y}, {r.Vertices[ p.VertexIndex[ 2 ] ].Z}) - {p.Unknown:X}"
+                    );
+                }
+            }
+
+            if( !( r.Children?.Count > 0 ) ) return;
+            
+            sb.AppendLine( $"{tabs}Children:" );
+            foreach( var c in r.Children )
+            {
+                Stringify( sb, c, tabs + "  " );
+            }
+        }
+    }
+}

--- a/src/Lumina/Data/Parsing/Common.cs
+++ b/src/Lumina/Data/Parsing/Common.cs
@@ -12,6 +12,11 @@ namespace Lumina.Data.Parsing
             {
                 return new Vector3 { X = br.ReadSingle(), Y = br.ReadSingle(), Z = br.ReadSingle() };
             }
+
+            public static Vector3 Read16( BinaryReader br )
+            {
+                return new Vector3 { X = (float)br.ReadUInt16() / 0xFFFF, Y = (float)br.ReadUInt16() / 0xFFFF, Z = (float)br.ReadUInt16() / 0xFFFF };
+            }
         };
 
         public struct Vector4
@@ -43,5 +48,20 @@ namespace Lumina.Data.Parsing
                 };
             }
         };
+        
+        public struct BoundingBox
+        {
+            public Vector3 Min;
+            public Vector3 Max;
+
+            public static BoundingBox Read( BinaryReader reader )
+            {
+                return new BoundingBox
+                {
+                    Min = Vector3.Read( reader ),
+                    Max = Vector3.Read( reader )
+                };
+            }
+        }
     }
 }


### PR DESCRIPTION
As said on the tin, if you do gameData.GetFile< PcbResourceFile >( "bg/ex3/01_nvt_n4/goe/n4gb/collision/tr1617.pcb" ), you'll get a PcbResourceFile object which you can then explore via its Nodes field; if you want to explore a list.pcb, you need to use PcbListFile because they have different structures.

Future thought is to make a class to integrate both of those so you can just LoadPcb( "bg/ex3/01_nvt_n4/goe/n4gb" ) and it'll load "collision/list.pcb" within that folder, and then load all the individual PcbResourceFiles referenced by that list (potentially into a more 'useful' representation, although I'm not entirely sure what that representation would look like yet).