### PR TITLE
Set _data in second BasePayload ctor

### DIFF
--- a/src/Lumina/Text/Payloads/BasePayload.cs
+++ b/src/Lumina/Text/Payloads/BasePayload.cs
@@ -25,6 +25,7 @@ namespace Lumina.Text.Payloads
 
             if( data.Any() )
             {
+                _data = data;
                 _rawString = Encoding.UTF8.GetString( data );
             }
         }


### PR DESCRIPTION
I was wondering why I couldn't access raw bytes. SeString only ever builds payloads with this constructor.