### PR TITLE
Fix `DeflateStream.Read` on net6.0

### DIFF
--- a/src/Lumina/Data/SqPackStream.cs
+++ b/src/Lumina/Data/SqPackStream.cs
@@ -317,11 +317,18 @@ namespace Lumina.Data
             {
                 using var zlibStream = new DeflateStream( BaseStream, CompressionMode.Decompress, true );
 
-                var bytesRead = zlibStream.Read( buffer, (int)dest.Position, (int)blockHeader.BlockDataSize );
-                if( bytesRead != (int)blockHeader.BlockDataSize )
+                var totalRead = 0;
+                while( totalRead < blockHeader.BlockDataSize )
+                {
+                    var bytesRead = zlibStream.Read( buffer, (int)dest.Position + totalRead, (int)blockHeader.BlockDataSize - totalRead );
+                    if( bytesRead == 0 ) { break; }
+                    totalRead += bytesRead;
+                }
+
+                if( totalRead != (int)blockHeader.BlockDataSize )
                 {
                     throw new SqPackInflateException(
-                        $"failed to inflate block, bytesRead ({bytesRead}) != BlockDataSize ({blockHeader.BlockDataSize})"
+                        $"failed to inflate block, bytesRead ({totalRead}) != BlockDataSize ({blockHeader.BlockDataSize})"
                     );
                 }
 


### PR DESCRIPTION
because apparently this is good API design.

ref. https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams

taking bets i fucked some code style

w/o this fix, reading `action` table results in a
```SqPackInflateException: failed to inflate block, bytesRead (14639) != BlockDataSize (16000)```
but i'm sure it's not limited to actions