### PR TITLE
Add a further lock on row parsing to prevent errors when loading from multiple threads.

### DIFF
--- a/src/Lumina/Data/Files/Excel/ExcelDataFile.cs
+++ b/src/Lumina/Data/Files/Excel/ExcelDataFile.cs
@@ -24,6 +24,8 @@ namespace Lumina.Data.Files.Excel
         /// Whether the endianness of the underlying data has been swapped so it doesn't happen twice
         /// </summary>
         public bool SwappedEndianness { get; internal set; }
+        
+        internal readonly object ReaderLock = new();
 
         public override unsafe void LoadFile()
         {

--- a/src/Lumina/Excel/ExcelSheet.cs
+++ b/src/Lumina/Excel/ExcelSheet.cs
@@ -50,9 +50,11 @@ namespace Lumina.Excel
             }
             
             var rowObj = Activator.CreateInstance< T >();
-            
-            lock(page.File.ReaderLock)
+
+            lock( page.File.ReaderLock )
+            {
                 rowObj.PopulateData( parser, GameData, RequestedLanguage );
+            }
 
             _rowCache[ cacheKey ] = rowObj;
 

--- a/src/Lumina/Excel/ExcelSheet.cs
+++ b/src/Lumina/Excel/ExcelSheet.cs
@@ -37,13 +37,17 @@ namespace Lumina.Excel
                 return cachedRow;
             }
 
-            var parser = GetRowParser( row, subRow );
+            var page = GetPageForRow( row );
+            if( page == null )
+            {
+                return null;
+            }
+            
+            var parser = GetRowParser( page, row, subRow );
             if( parser == null )
             {
                 return null;
             }
-
-            var page = GetPageForRow( row );
             
             var rowObj = Activator.CreateInstance< T >();
             

--- a/src/Lumina/Excel/ExcelSheetImpl.cs
+++ b/src/Lumina/Excel/ExcelSheetImpl.cs
@@ -310,6 +310,29 @@ namespace Lumina.Excel
 
             return parser;
         }
+
+        /// <summary>
+        /// Provides direct access to the underlying row parser for any row or subrow
+        /// </summary>
+        /// <param name="page">The excel page to operate on</param>
+        /// <param name="row">The row id to seek to</param>
+        /// <param name="subRow">The subrow id to seek to</param>
+        /// <returns>A <see cref="RowParser"/> instance</returns>
+        public RowParser? GetRowParser( ExcelPage page, uint row, uint subRow = uint.MaxValue )
+        {
+            RowParser parser = null!;
+
+            if( subRow != uint.MaxValue )
+            {
+                parser = new RowParser( this, page.File, row, subRow );
+            }
+            else
+            {
+                parser = new RowParser( this, page.File, row );
+            }
+
+            return parser;
+        }
         
         /// <summary>
         /// Iterate across each row data offsets in a sheet


### PR DESCRIPTION
The XIV Stream Deck plugin requires the use of an embedded web server for the purposes of the plugin and interfacing with the Elgato software. As the EmbedIO server is in a different thread (for obvious reasons), data access to sheets may be called from multiple threads. This added lock prevents threads from modifying the RowParser's seek position while reading is taking place.