### PR TITLE
Fall back to the original ProcessA8R8G8B8 method

### DIFF
--- a/src/Lumina/Data/Files/TexFile.cs
+++ b/src/Lumina/Data/Files/TexFile.cs
@@ -143,7 +143,7 @@ namespace Lumina.Data.Files
                     ProcessR3G3B2( src, dst, width, height );
                     break;
                 case TextureFormat.A8R8G8B8:
-                    src.CopyTo( dst );
+                    ProcessA8R8G8B8( src, dst, width, height );
                     break;
                 default:
                     throw new NotImplementedException( $"TextureFormat {Header.Format.ToString()} is not supported for image conversion." );


### PR DESCRIPTION
Copying the A8R8G8B8 buffer directly into the pixel data destination buffer does not work for some files that have extra data for some reason. The original method which determines which buffer is larger and only copies what is possible is working properly, so I swapped the Convert method to use this.