### PR TITLE
Fix overflow in hash table offsets

### DIFF
--- a/src/Lumina/Data/Structs/SqPackIndexHeader.cs
+++ b/src/Lumina/Data/Structs/SqPackIndexHeader.cs
@@ -37,7 +37,7 @@ namespace Lumina.Data.Structs
 
         public byte DataFileId => (byte) ( ( data & 0b1110 ) >> 1 );
 
-        public long Offset => (uint) ( data & ~0xF ) * 0x08;
+        public long Offset => ( (uint)data & ~0xF ) * 0x08;
     }
     
     [StructLayout( LayoutKind.Sequential )]
@@ -50,6 +50,6 @@ namespace Lumina.Data.Structs
 
         public byte DataFileId => (byte) ( ( data & 0b1110 ) >> 1 );
 
-        public long Offset => (uint) ( data & ~0xF ) * 0x08;
+        public long Offset => ( (uint)data & ~0xF ) * 0x08;
     }
 }


### PR DESCRIPTION
Fixes hash table offsets wrapping into uint range when reading files modified by TexTools.