### PR TITLE
Add support for multiple mipmaps/depths for TexFile

### DIFF
--- a/src/Lumina/Data/Files/TexFile.cs
+++ b/src/Lumina/Data/Files/TexFile.cs
@@ -2,8 +2,9 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Lumina.Data.Attributes;
-using Lumina.Data.Parsing.Tex;
+using Lumina.Data.Parsing.Tex.Buffers;
 using Lumina.Extensions;
+
 // ReSharper disable InconsistentNaming
 
 namespace Lumina.Data.Files
@@ -11,6 +12,7 @@ namespace Lumina.Data.Files
     [FileExtension( ".tex" )]
     public class TexFile : FileResource
     {
+        [Flags]
         public enum Attribute : uint
         {
             DiscardPerFrame = 0x1,
@@ -37,9 +39,16 @@ namespace Lumina.Data.Files
             TextureNoSwizzle = 0x80000000,
         }
 
+        /// <summary>
+        /// Texture formats. Channel ordering in name follows the enumeration in DXGI_FORMAT.
+        ///
+        /// Excerpt from: https://docs.microsoft.com/en-us/windows/win32/api/dxgiformat/ne-dxgiformat-dxgi_format
+        /// > Most formats have byte-aligned components, and the components are in C-array order (the least address comes first).
+        /// > For those formats that don't have power-of-2-aligned components, the first named component is in the least-significant bits.  
+        /// </summary>
+        [Flags]
         public enum TextureFormat
         {
-            Unknown = 0x0,
             TypeShift = 0xC,
             TypeMask = 0xF000,
             ComponentShift = 0x8,
@@ -51,32 +60,58 @@ namespace Lumina.Data.Files
             TypeInteger = 0x1,
             TypeFloat = 0x2,
             TypeDxt = 0x3,
+            TypeBc123 = 0x3,
             TypeDepthStencil = 0x4,
             TypeSpecial = 0x5,
-            A8R8G8B8 = 0x1450,
-
-            // todo:
-            R8G8B8X8 = 0x1451,
-            A8R8G8B82 = 0x1452,
-            R4G4B4A4 = 0x1440,
-            R5G5B5A1 = 0x1441,
+            TypeBc57 = 0x6,
+            
+            Unknown = 0x0,
+            
+            // Integer types
             L8 = 0x1130,
-
-            // todo:
             A8 = 0x1131,
-
-            // todo:
+            B4G4R4A4 = 0x1440,
+            B5G5R5A1 = 0x1441,
+            B8G8R8A8 = 0x1450,
+            B8G8R8X8 = 0x1451,
+            
+            [Obsolete("Use B4G4R4A4 instead.")]
+            R4G4B4A4 = 0x1440,
+            [Obsolete("Use B5G5R5A1 instead.")]
+            R5G5B5A1 = 0x1441,
+            [Obsolete("Use B8G8R8A8 instead.")]
+            A8R8G8B8 = 0x1450,
+            [Obsolete("Use B8G8R8X8 instead.")]
+            R8G8B8X8 = 0x1451,
+            [Obsolete("Not supported by Windows DirectX 11 version of the game, nor have any mention of the value, as of 6.15.")]
+            A8R8G8B82 = 0x1452,
+            
+            // Floating point types
             R32F = 0x2150,
-            R32G32B32A32F = 0x2470,
             R16G16F = 0x2250,
+            R32G32F = 0x2260,
             R16G16B16A16F = 0x2460,
+            R32G32B32A32F = 0x2470,
+            
+            // Block compression types (DX9 names)
             DXT1 = 0x3420,
             DXT3 = 0x3430,
             DXT5 = 0x3431,
+            ATI2 = 0x6230,
+            
+            // Block compression types (DX11 names)
+            BC1 = 0x3420,
+            BC2 = 0x3430,
+            BC3 = 0x3431,
+            BC5 = 0x6230,
+            BC7 = 0x6432,
+
+            // Depth stencil types
+            // Does not exist in ffxiv_dx11.exe: RGBA8 0x4401
             D16 = 0x4140,
             D24S8 = 0x4250,
 
-            //todo: RGBA8 0x4401
+            // Special types
             Null = 0x5100,
             Shadow16 = 0x5140,
             Shadow24 = 0x5150,
@@ -95,146 +130,109 @@ namespace Lumina.Data.Files
             public fixed uint OffsetToSurface[13];
         };
 
+        /// <summary>
+        /// Specify preprocessing texture data for consumption in DXGI.
+        /// </summary>
+        public enum DxgiFormatConversion
+        {
+            /// <summary>
+            /// No conversion is required.
+            /// </summary>
+            NoConversion,
+            
+            /// <summary>
+            /// Conversion from L8 (8bpp) to B8G8R8A8 (32bpp) is required.
+            /// Each byte indicates color value for each RGB channel. Alpha channel is fixed to 255.
+            /// </summary>
+            FromL8ToB8G8R8A8,
+            
+            /// <summary>
+            /// Conversion from B4G4R4A4 (16bpp) to B8G8R8A8 (32bpp) is required.
+            /// </summary>
+            FromB4G4R4A4ToB8G8R8A8,
+            
+            /// <summary>
+            /// Conversion from B5G5R5A1 (16bpp) to B8G8R8A8 (32bpp) is required.
+            /// </summary>
+            FromB5G5R5A1ToB8G8R8A8,
+        }
+
+        private byte[]? _imageDataDefault;
+
         public TexHeader Header;
 
         public int HeaderLength => Unsafe.SizeOf< TexHeader >();
 
         /// <summary>
-        /// The converted A8R8G8B8 image, in bytes.
+        /// Parsed texture buffer, in original texture format.
         /// </summary>
-        public byte[] ImageData { get; private set; }
+        public TextureBuffer TextureBuffer;
+
+        /// <summary>
+        /// The converted A8R8G8B8 image, taking the first Z/face/mipmap.
+        /// </summary>
+        public byte[] ImageData
+        {
+            get
+            {
+                _imageDataDefault ??= TextureBuffer.Filter( mip: 0, z: 0, format: TextureFormat.B8G8R8A8 ).RawData;
+                return _imageDataDefault;
+            }
+        }
 
         public override void LoadFile()
         {
             Reader.BaseStream.Position = 0;
             Header = Reader.ReadStructure< TexHeader >();
 
-            // todo: this isn't correct and reads out the whole data portion as 1 image instead of accounting for lod levels
-            // probably a breaking change to fix this
-            ImageData = Convert( DataSpan.Slice( HeaderLength ), Header.Width, Header.Height );
+            if( ( Header.Type & Attribute.TextureTypeCube ) != 0 && Header.Depth != 1 )
+                throw new NotSupportedException( "Cube map texture with depth value above 1 is currently not supported." );
+
+            TextureBuffer = TextureBuffer.FromStream( Header, Reader );
         }
 
-        // converts various formats to A8R8G8B8
-        private byte[] Convert( Span< byte > src, int width, int height )
+        /// <summary>
+        /// Get DXGI_FORMAT and required preprocessing from TextureFormat.
+        /// </summary>
+        /// <param name="format">.tex texture format value.</param>
+        /// <param name="useGameCompatible">Whether to emulate the game on preprocessing texture data.</param>
+        /// <remarks>
+        /// Values are taken from v6.15 ffxiv_dx11.exe+0x321f80.
+        /// </remarks>
+        public static Tuple< int, DxgiFormatConversion > GetDxgiFormatFromTextureFormat( TextureFormat format, bool useGameCompatible = true )
         {
-            byte[] dst = new byte[width * height * 4];
-
-            switch( Header.Format )
+            return format switch
             {
-                case TextureFormat.DXT1:
-                    ProcessDxt1( src, dst, width, height );
-                    break;
-                case TextureFormat.DXT3:
-                    ProcessDxt3( src, dst, width, height );
-                    break;
-                case TextureFormat.DXT5:
-                    ProcessDxt5( src, dst, width, height );
-                    break;
-                case TextureFormat.R16G16B16A16F:
-                    ProcessA16R16G16B16_Float( src, dst, width, height );
-                    break;
-                case TextureFormat.R5G5B5A1:
-                    ProcessA1R5G5B5( src, dst, width, height );
-                    break;
-                case TextureFormat.R4G4B4A4:
-                    ProcessA4R4G4B4( src, dst, width, height );
-                    break;
-                case TextureFormat.L8:
-                    ProcessR3G3B2( src, dst, width, height );
-                    break;
-                case TextureFormat.A8R8G8B8:
-                    ProcessA8R8G8B8( src, dst, width, height );
-                    break;
-                default:
-                    throw new NotImplementedException( $"TextureFormat {Header.Format.ToString()} is not supported for image conversion." );
-            }
-
-            return dst;
-        }
-
-        // #region shamelessly copied from coinach
-        // might be slowed down by src copying when calling squish
-        private static void ProcessA16R16G16B16_Float( Span< byte > src, byte[] dst, int width, int height )
-        {
-            // Clipping can, and will occur since values go outside 0..1
-            for( var i = 0; i < width * height; ++i )
-            {
-                var srcOff = i * 4 * 2;
-                var dstOff = i * 4;
-
-                for( var j = 0; j < 4; ++j )
-                    dst[ dstOff + j ] = (byte)( src.Unpack( srcOff + j * 2 ) * byte.MaxValue );
-            }
-        }
-
-        private static void ProcessA1R5G5B5( Span< byte > src, byte[] dst, int width, int height )
-        {
-            for( var i = 0; ( i + 2 ) <= 2 * width * height; i += 2 )
-            {
-                var v = BitConverter.ToUInt16( src.Slice( i, sizeof( UInt16 ) ).ToArray(), 0 );
-
-                var a = (uint)( v & 0x8000 );
-                var r = (uint)( v & 0x7C00 );
-                var g = (uint)( v & 0x03E0 );
-                var b = (uint)( v & 0x001F );
-
-                var rgb = ( ( r << 9 ) | ( g << 6 ) | ( b << 3 ) );
-                var argbValue = ( a * 0x1FE00 | rgb | ( ( rgb >> 5 ) & 0x070707 ) );
-
-                for( var j = 0; j < 4; ++j )
-                    dst[ i * 2 + j ] = (byte)( argbValue >> ( 8 * j ) );
-            }
-        }
-
-        private static void ProcessA4R4G4B4( Span< byte > src, byte[] dst, int width, int height )
-        {
-            for( var i = 0; ( i + 2 ) <= 2 * width * height; i += 2 )
-            {
-                var v = BitConverter.ToUInt16( src.Slice( i, sizeof( UInt16 ) ).ToArray(), 0 );
-
-                for( var j = 0; j < 4; ++j )
-                    dst[ i * 2 + j ] = (byte)( ( ( v >> ( 4 * j ) ) & 0x0F ) << 4 );
-            }
-        }
-
-        private static void ProcessA8R8G8B8( Span< byte > src, byte[] dst, int width, int height )
-        {
-            // Some transparent images have larger dst lengths than their src.
-            var length = Math.Min( src.Length, dst.Length );
-            src.Slice( 0, length ).CopyTo( dst.AsSpan() );
-        }
-
-        private static void ProcessDxt1( Span< byte > src, byte[] dst, int width, int height )
-        {
-            var dec = Squish.DecompressImage( src.ToArray(), width, height, SquishOptions.DXT1 );
-            Array.Copy( dec, dst, dst.Length );
-        }
-
-        private static void ProcessDxt3( Span< byte > src, byte[] dst, int width, int height )
-        {
-            var dec = Squish.DecompressImage( src.ToArray(), width, height, SquishOptions.DXT3 );
-            Array.Copy( dec, dst, dst.Length );
-        }
-
-        private static void ProcessDxt5( Span< byte > src, byte[] dst, int width, int height )
-        {
-            var dec = Squish.DecompressImage( src.ToArray(), width, height, SquishOptions.DXT5 );
-            Array.Copy( dec, dst, dst.Length );
-        }
-
-        private static void ProcessR3G3B2( Span< byte > src, byte[] dst, int width, int height )
-        {
-            for( var i = 0; i < width * height; ++i )
-            {
-                var r = (uint)( src[ i ] & 0xE0 );
-                var g = (uint)( src[ i ] & 0x1C );
-                var b = (uint)( src[ i ] & 0x03 );
-
-                dst[ i * 4 + 0 ] = (byte)( b | ( b << 2 ) | ( b << 4 ) | ( b << 6 ) );
-                dst[ i * 4 + 1 ] = (byte)( g | ( g << 3 ) | ( g << 6 ) );
-                dst[ i * 4 + 2 ] = (byte)( r | ( r << 3 ) | ( r << 6 ) );
-                dst[ i * 4 + 3 ] = 0xFF;
-            }
+                TextureFormat.Unknown => Tuple.Create( 0x00, DxgiFormatConversion.NoConversion ), // DXGI_FORMAT_UNKNOWN
+                TextureFormat.Null => Tuple.Create( 0x00, DxgiFormatConversion.NoConversion ), // DXGI_FORMAT_UNKNOWN
+                TextureFormat.R32G32B32A32F => Tuple.Create( 0x02, DxgiFormatConversion.NoConversion ), // DXGI_FORMAT_R32G32B32A32_FLOAT
+                TextureFormat.R16G16B16A16F => Tuple.Create( 0x0a, DxgiFormatConversion.NoConversion ), // DXGI_FORMAT_R16G16B16A16_FLOAT
+                TextureFormat.R32G32F => Tuple.Create( 0x10, DxgiFormatConversion.NoConversion ), // DXGI_FORMAT_R32G32_FLOAT
+                TextureFormat.R16G16F => Tuple.Create( 0x22, DxgiFormatConversion.NoConversion ), // DXGI_FORMAT_R16G16_FLOAT 
+                TextureFormat.R32F => Tuple.Create( 0x29, DxgiFormatConversion.NoConversion ), // DXGI_FORMAT_R32_FLOAT
+                TextureFormat.D24S8 => Tuple.Create( 0x2c, DxgiFormatConversion.NoConversion ), // DXGI_FORMAT_R24G8_TYPELESS
+                TextureFormat.Shadow24 => Tuple.Create( 0x2c, DxgiFormatConversion.NoConversion ), // DXGI_FORMAT_R24G8_TYPELESS
+                TextureFormat.D16 => Tuple.Create( 0x35, DxgiFormatConversion.NoConversion ), // DXGI_FORMAT_R16_TYPELESS
+                TextureFormat.Shadow16 => Tuple.Create( 0x35, DxgiFormatConversion.NoConversion ), // DXGI_FORMAT_R16_TYPELESS
+                TextureFormat.A8 => Tuple.Create( 0x41, DxgiFormatConversion.NoConversion ), // DXGI_FORMAT_A8_UNORM
+                TextureFormat.BC1 => Tuple.Create( 0x47, DxgiFormatConversion.NoConversion ), // DXGI_FORMAT_BC1_UNORM
+                TextureFormat.BC2 => Tuple.Create( 0x4a, DxgiFormatConversion.NoConversion ), // DXGI_FORMAT_BC2_UNORM
+                TextureFormat.BC3 => Tuple.Create( 0x4d, DxgiFormatConversion.NoConversion ), // DXGI_FORMAT_BC3_UNORM
+                TextureFormat.BC5 => Tuple.Create( 0x53, DxgiFormatConversion.NoConversion ), // DXGI_FORMAT_BC5_UNORM
+                TextureFormat.L8 => Tuple.Create( 0x57, DxgiFormatConversion.FromL8ToB8G8R8A8 ), // each pixel is RGBA(x, x, x, 255)
+                TextureFormat.B4G4R4A4 => useGameCompatible
+                    ? Tuple.Create( 0x57, DxgiFormatConversion.FromB4G4R4A4ToB8G8R8A8 ) // DXGI_FORMAT_B8G8R8A8_UNORM
+                    : Tuple.Create( 0x73, DxgiFormatConversion.NoConversion ) // DXGI_FORMAT_B4G4R4A4_UNORM
+                , // DXGI_FORMAT_B4G4R4A4_UNORM(0x73): unsupported in dx10, dx10.1, dx11, and dx11.1 (before windows8)
+                TextureFormat.B5G5R5A1 =>useGameCompatible
+                    ? Tuple.Create( 0x57, DxgiFormatConversion.FromB5G5R5A1ToB8G8R8A8 ) // DXGI_FORMAT_B8G8R8A8_UNORM
+                    : Tuple.Create( 0x56, DxgiFormatConversion.NoConversion ) // DXGI_FORMAT_B5G5R5A1_UNORM
+                , // DXGI_FORMAT_B5G5R5A1_UNORM(0x56): unsupported in dx10, dx10.1, dx11, and dx11.1 (before windows8)
+                TextureFormat.B8G8R8A8 => Tuple.Create( 0x57, DxgiFormatConversion.NoConversion ), // DXGI_FORMAT_B8G8R8A8_UNORM
+                TextureFormat.B8G8R8X8 => Tuple.Create( 0x58, DxgiFormatConversion.NoConversion ), // DXGI_FORMAT_B8G8R8X8_UNORM
+                TextureFormat.BC7 => Tuple.Create( 0x62, DxgiFormatConversion.NoConversion ), // DXGI_FORMAT_BC7_UNORM
+                _ => throw new NotSupportedException($"TextureFormat {(int)format:X04} is not supported."),
+            };
         }
     }
 }

--- a/src/Lumina/Data/Parsing/Tex/Buffers/A8TextureBuffer.cs
+++ b/src/Lumina/Data/Parsing/Tex/Buffers/A8TextureBuffer.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Lumina.Data.Parsing.Tex.Buffers
+{
+    /// <summary>
+    /// Represent a face in .tex file, in A8 texture format.
+    /// </summary>
+    public class A8TextureBuffer : TextureBuffer
+    {
+        /// <inheritdoc />
+        public A8TextureBuffer( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            : base( isDepthConstant, width, height, depth, mipmapAllocations, buffer )
+        {
+        }
+
+        /// <inheritdoc />
+        public override int NumBytesOfMipmapPerPlane( int mipmapIndex ) => NumPixelsOfMipmapPerPlane( mipmapIndex );
+
+        /// <inheritdoc />
+        protected override unsafe void ConvertToB8G8R8A8( byte[] buffer, int destOffset, int sourceOffset, int width, int height, int depth )
+        {
+            fixed( byte* dstb = buffer, srcb = RawData )
+            {
+                var src = new Span< byte >( srcb + sourceOffset, width * height * depth );
+                var dst = new Span< uint >( dstb + destOffset, width * height * depth );
+                for( var i = 0; i < dst.Length; i++ )
+                    dst[ i ] = 0x1000000U * src[ i ];
+            }
+        }
+
+        /// <inheritdoc />
+        protected override TextureBuffer CreateNew( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            => new A8TextureBuffer( isDepthConstant, width, height, depth, mipmapAllocations, buffer );
+    }
+}

--- a/src/Lumina/Data/Parsing/Tex/Buffers/B4G4R4A4TextureBuffer.cs
+++ b/src/Lumina/Data/Parsing/Tex/Buffers/B4G4R4A4TextureBuffer.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace Lumina.Data.Parsing.Tex.Buffers
+{
+    /// <summary>
+    /// Represent a face in .tex file, in B4G4R4A4 texture format.
+    /// </summary>
+    public class B4G4R4A4TextureBuffer : TextureBuffer
+    {
+        /// <inheritdoc />
+        public B4G4R4A4TextureBuffer( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            : base( isDepthConstant, width, height, depth, mipmapAllocations, buffer )
+        {
+        }
+
+        /// <inheritdoc />
+        public override int NumBytesOfMipmapPerPlane( int mipmapIndex ) => NumPixelsOfMipmapPerPlane( mipmapIndex ) * 2;
+
+        /// <inheritdoc />
+        protected override unsafe void ConvertToB8G8R8A8( byte[] buffer, int destOffset, int sourceOffset, int width, int height, int depth )
+        {
+            fixed( byte* dstb = buffer, srcb = RawData )
+            {
+                var src = new Span< ushort >( srcb + sourceOffset, width * height * depth );
+                var dst = new Span< uint >( dstb + destOffset, width * height * depth );
+                for( var i = 0; i < dst.Length; i++ )
+                {
+                    dst[ i ] = (uint)( 17U * (
+                        ( ( ( src[ i ] >> 0 ) & 0xF ) << 0 )
+                        | ( ( ( src[ i ] >> 4 ) & 0xF ) << 8 )
+                        | ( ( ( src[ i ] >> 8 ) & 0xF ) << 16 )
+                        | ( ( ( src[ i ] >> 12 ) & 0xF ) << 24 )
+                    ) );
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        protected override TextureBuffer CreateNew( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            => new B4G4R4A4TextureBuffer( isDepthConstant, width, height, depth, mipmapAllocations, buffer );
+    }
+}

--- a/src/Lumina/Data/Parsing/Tex/Buffers/B5G5R5A1TextureBuffer.cs
+++ b/src/Lumina/Data/Parsing/Tex/Buffers/B5G5R5A1TextureBuffer.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace Lumina.Data.Parsing.Tex.Buffers
+{
+    /// <summary>
+    /// Represent a face in .tex file, in B5G5R5A1 texture format.
+    /// </summary>
+    public class B5G5R5A1TextureBuffer : TextureBuffer
+    {
+        /// <inheritdoc />
+        public B5G5R5A1TextureBuffer( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            : base( isDepthConstant, width, height, depth, mipmapAllocations, buffer )
+        {
+        }
+
+        /// <inheritdoc />
+        public override int NumBytesOfMipmapPerPlane( int mipmapIndex ) => NumPixelsOfMipmapPerPlane( mipmapIndex ) * 2;
+
+        /// <inheritdoc />
+        protected override unsafe void ConvertToB8G8R8A8( byte[] buffer, int destOffset, int sourceOffset, int width, int height, int depth )
+        {
+            fixed( byte* dstb = buffer, srcb = RawData )
+            {
+                var src = new Span< ushort >( srcb + sourceOffset, width * height * depth );
+                var dst = new Span< uint >( dstb + destOffset, width * height * depth );
+                for( var i = 0; i < dst.Length; i++ )
+                {
+                    var a = (uint)( src[ i ] & 0x8000 );
+                    var r = (uint)( src[ i ] & 0x7C00 );
+                    var g = (uint)( src[ i ] & 0x03E0 );
+                    var b = (uint)( src[ i ] & 0x001F );
+
+                    var rgb = ( r << 9 ) | ( g << 6 ) | ( b << 3 );
+                    dst[ i ] = ( a * 0x1FE00 ) | rgb | ( ( rgb >> 5 ) & 0x070707 );
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        protected override TextureBuffer CreateNew( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            => new B5G5R5A1TextureBuffer( isDepthConstant, width, height, depth, mipmapAllocations, buffer );
+    }
+}

--- a/src/Lumina/Data/Parsing/Tex/Buffers/B8G8R8A8TextureBuffer.cs
+++ b/src/Lumina/Data/Parsing/Tex/Buffers/B8G8R8A8TextureBuffer.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Lumina.Data.Parsing.Tex.Buffers
+{
+    /// <summary>
+    /// Represent a face in .tex file, in B8G8R8A8 texture format.
+    /// </summary>
+    public class B8G8R8A8TextureBuffer : TextureBuffer
+    {
+        /// <inheritdoc />
+        public B8G8R8A8TextureBuffer( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            : base( isDepthConstant, width, height, depth, mipmapAllocations, buffer )
+        {
+        }
+
+        /// <inheritdoc />
+        public override int NumBytesOfMipmapPerPlane( int mipmapIndex ) => NumPixelsOfMipmapPerPlane( mipmapIndex ) * 4;
+
+        /// <inheritdoc />
+        protected override void ConvertToB8G8R8A8( byte[] buffer, int destOffset, int sourceOffset, int width, int height, int depth )
+            => Buffer.BlockCopy( RawData, sourceOffset, buffer, destOffset, width * height * depth * 4 );
+
+        /// <inheritdoc />
+        protected override TextureBuffer CreateNew( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            => new B8G8R8A8TextureBuffer( isDepthConstant, width, height, depth, mipmapAllocations, buffer );
+    }
+}

--- a/src/Lumina/Data/Parsing/Tex/Buffers/B8G8R8X8TextureBuffer.cs
+++ b/src/Lumina/Data/Parsing/Tex/Buffers/B8G8R8X8TextureBuffer.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Lumina.Data.Parsing.Tex.Buffers
+{
+    /// <summary>
+    /// Represent a face in .tex file, in B8G8R8X8 texture format.
+    /// </summary>
+    public class B8G8R8X8TextureBuffer : TextureBuffer
+    {
+        /// <inheritdoc />
+        public B8G8R8X8TextureBuffer( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            : base( isDepthConstant, width, height, depth, mipmapAllocations, buffer )
+        {
+        }
+
+        /// <inheritdoc />
+        public override int NumBytesOfMipmapPerPlane( int mipmapIndex ) => NumPixelsOfMipmapPerPlane( mipmapIndex ) * 4;
+
+        /// <inheritdoc />
+        protected override unsafe void ConvertToB8G8R8A8( byte[] buffer, int destOffset, int sourceOffset, int width, int height, int depth )
+        {
+            fixed( byte* dstb = buffer, srcb = RawData )
+            {
+                var src = new Span< uint >( srcb + sourceOffset, width * height * depth );
+                var dst = new Span< uint >( dstb + destOffset, width * height * depth );
+                for( var i = 0; i < dst.Length; i++ )
+                    dst[ i ] = 0xFF000000U | src[ i ];
+            }
+        }
+
+        /// <inheritdoc />
+        protected override TextureBuffer CreateNew( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            => new B8G8R8X8TextureBuffer( isDepthConstant, width, height, depth, mipmapAllocations, buffer );
+    }
+}

--- a/src/Lumina/Data/Parsing/Tex/Buffers/BlockCompressionTextureBuffer.cs
+++ b/src/Lumina/Data/Parsing/Tex/Buffers/BlockCompressionTextureBuffer.cs
@@ -1,0 +1,81 @@
+using System;
+using Lumina.Data.Files;
+
+namespace Lumina.Data.Parsing.Tex.Buffers
+{
+    /// <summary>
+    /// Represent a face in .tex file, in either BC1(DXT1), BC2(DXT3), BC3(DXT5), BC5(ATI2), or BC7 texture format.
+    /// </summary>
+    public class BlockCompressionTextureBuffer : TextureBuffer
+    {
+        private readonly SquishOptions _squishOption;
+        private readonly int _lengthPerDxtBlock;
+
+        private BlockCompressionTextureBuffer( SquishOptions squishOption, int lengthPerDxtBlock, bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            : base( isDepthConstant, width, height, depth, mipmapAllocations, buffer )
+        {
+            _squishOption = squishOption;
+            _lengthPerDxtBlock = lengthPerDxtBlock;
+        }
+
+        /// <inheritdoc />
+        public BlockCompressionTextureBuffer( TexFile.TextureFormat format, bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            : base( isDepthConstant, width, height, depth, mipmapAllocations, buffer )
+        {
+            switch( format )
+            {
+                case TexFile.TextureFormat.BC1:
+                    _squishOption = SquishOptions.DXT1;
+                    _lengthPerDxtBlock = 8;
+                    break;
+                case TexFile.TextureFormat.BC2:
+                    _squishOption = SquishOptions.DXT3;
+                    _lengthPerDxtBlock = 16;
+                    break;
+                case TexFile.TextureFormat.BC3:
+                    _squishOption = SquishOptions.DXT5;
+                    _lengthPerDxtBlock = 16;
+                    break;
+                case TexFile.TextureFormat.BC5:
+                case TexFile.TextureFormat.BC7:
+                    _squishOption = SquishOptions.None;
+                    _lengthPerDxtBlock = 16;
+                    break;
+                default:
+                    throw new InvalidOperationException( "Not a DXT texture format" );
+            }
+        }
+
+        /// <inheritdoc />
+        public override int NumBytesOfMipmapPerPlane( int mipmapIndex ) =>
+            CalculateNumBytesPerPlane(WidthOfMipmap( mipmapIndex ), HeightOfMipmap( mipmapIndex ));
+        
+        /// <inheritdoc />
+        protected override void ConvertToB8G8R8A8( byte[] buffer, int destOffset, int sourceOffset, int width, int height, int depth )
+        {
+            if( _squishOption == SquishOptions.None )
+                throw new NotSupportedException( "Decoding BC5/BC7 data is currently not supported." );
+            
+            var cbPlane = CalculateNumBytesPerPlane( width, height );
+            for( var i = 0; i < depth; i++ )
+            {
+                var dec = Squish.DecompressImage( RawData, sourceOffset + cbPlane * i, width, height, _squishOption );
+                Array.Copy(
+                    dec,
+                    0,
+                    buffer,
+                    destOffset + width * height * 4 * i,
+                    dec.Length );
+            }
+        }
+
+        /// <inheritdoc />
+        protected override TextureBuffer CreateNew( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            => new BlockCompressionTextureBuffer( _squishOption, _lengthPerDxtBlock, isDepthConstant, width, height, depth, mipmapAllocations, buffer );
+
+        private int CalculateNumBytesPerPlane( int w, int h ) =>
+            Math.Max( 1, ( ( w + 3 ) / 4 ) ) *
+            Math.Max( 1, ( ( h + 3 ) / 4 ) ) *
+            _lengthPerDxtBlock;
+    }
+}

--- a/src/Lumina/Data/Parsing/Tex/Buffers/L8TextureBuffer.cs
+++ b/src/Lumina/Data/Parsing/Tex/Buffers/L8TextureBuffer.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Lumina.Data.Parsing.Tex.Buffers
+{
+    /// <summary>
+    /// Represent a face in .tex file, in L8 texture format.
+    /// </summary>
+    public class L8TextureBuffer : TextureBuffer
+    {
+        /// <inheritdoc />
+        public L8TextureBuffer( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            : base( isDepthConstant, width, height, depth, mipmapAllocations, buffer )
+        {
+        }
+
+        /// <inheritdoc />
+        public override int NumBytesOfMipmapPerPlane( int mipmapIndex ) => NumPixelsOfMipmapPerPlane( mipmapIndex );
+
+        /// <inheritdoc />
+        protected override unsafe void ConvertToB8G8R8A8( byte[] buffer, int destOffset, int sourceOffset, int width, int height, int depth )
+        {
+            fixed( byte* dstb = buffer, srcb = RawData )
+            {
+                var src = new Span< byte >( srcb + sourceOffset, width * height * depth );
+                var dst = new Span< uint >( dstb + destOffset, width * height * depth );
+                for( var i = 0; i < dst.Length; i++ )
+                    dst[ i ] = 0xFF000000U | ( 0x10101U * src[ i ] );
+            }
+        }
+
+        /// <inheritdoc />
+        protected override TextureBuffer CreateNew( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            => new L8TextureBuffer( isDepthConstant, width, height, depth, mipmapAllocations, buffer );
+    }
+}

--- a/src/Lumina/Data/Parsing/Tex/Buffers/R16G16B16A16FTextureBuffer.cs
+++ b/src/Lumina/Data/Parsing/Tex/Buffers/R16G16B16A16FTextureBuffer.cs
@@ -24,8 +24,13 @@ namespace Lumina.Data.Parsing.Tex.Buffers
             {
                 var src = new Span< ushort >( srcb + sourceOffset, width * height * depth * 4 );
                 var dst = new Span< byte >( dstb + destOffset, width * height * depth * 4 );
-                for( var i = 0; i < dst.Length; i++ )
-                    dst[ i ] = (byte)Math.Round( src[ i ].Unpack() * byte.MaxValue );
+                for( var i = 0; i < dst.Length; i += 4 )
+                {
+                    dst[ i + 0 ] = (byte)Math.Round( src[ i + 2 ].Unpack() * byte.MaxValue );
+                    dst[ i + 1 ] = (byte)Math.Round( src[ i + 1 ].Unpack() * byte.MaxValue );
+                    dst[ i + 2 ] = (byte)Math.Round( src[ i + 0 ].Unpack() * byte.MaxValue );
+                    dst[ i + 3 ] = (byte)Math.Round( src[ i + 3 ].Unpack() * byte.MaxValue );
+                }
             }
         }
 

--- a/src/Lumina/Data/Parsing/Tex/Buffers/R16G16B16A16FTextureBuffer.cs
+++ b/src/Lumina/Data/Parsing/Tex/Buffers/R16G16B16A16FTextureBuffer.cs
@@ -1,0 +1,36 @@
+using System;
+using Lumina.Extensions;
+
+namespace Lumina.Data.Parsing.Tex.Buffers
+{
+    /// <summary>
+    /// Represent a face in .tex file, in R16G16B16A16F texture format.
+    /// </summary>
+    public class R16G16B16A16FTextureBuffer : TextureBuffer
+    {
+        /// <inheritdoc />
+        public R16G16B16A16FTextureBuffer( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            : base( isDepthConstant, width, height, depth, mipmapAllocations, buffer )
+        {
+        }
+
+        /// <inheritdoc />
+        public override int NumBytesOfMipmapPerPlane( int mipmapIndex ) => NumPixelsOfMipmapPerPlane( mipmapIndex ) * 8;
+
+        /// <inheritdoc />
+        protected override unsafe void ConvertToB8G8R8A8( byte[] buffer, int destOffset, int sourceOffset, int width, int height, int depth )
+        {
+            fixed( byte* dstb = buffer, srcb = RawData )
+            {
+                var src = new Span< ushort >( srcb + sourceOffset, width * height * depth * 4 );
+                var dst = new Span< byte >( dstb + destOffset, width * height * depth * 4 );
+                for( var i = 0; i < dst.Length; i++ )
+                    dst[ i ] = (byte)Math.Round( src[ i ].Unpack() * byte.MaxValue );
+            }
+        }
+
+        /// <inheritdoc />
+        protected override TextureBuffer CreateNew( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            => new R16G16B16A16FTextureBuffer( isDepthConstant, width, height, depth, mipmapAllocations, buffer );
+    }
+}

--- a/src/Lumina/Data/Parsing/Tex/Buffers/R32G32B32A32FTextureBuffer.cs
+++ b/src/Lumina/Data/Parsing/Tex/Buffers/R32G32B32A32FTextureBuffer.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Lumina.Data.Parsing.Tex.Buffers
+{
+    /// <summary>
+    /// Represent a face in .tex file, in R32G32B32A32F texture format.
+    /// </summary>
+    public class R32G32B32A32FTextureBuffer : TextureBuffer
+    {
+        /// <inheritdoc />
+        public R32G32B32A32FTextureBuffer( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            : base( isDepthConstant, width, height, depth, mipmapAllocations, buffer )
+        {
+        }
+
+        /// <inheritdoc />
+        public override int NumBytesOfMipmapPerPlane( int mipmapIndex ) => NumPixelsOfMipmapPerPlane( mipmapIndex ) * 16;
+
+        /// <inheritdoc />
+        protected override unsafe void ConvertToB8G8R8A8( byte[] buffer, int destOffset, int sourceOffset, int width, int height, int depth )
+        {
+            fixed( byte* dstb = buffer, srcb = RawData )
+            {
+                var src = new Span< float >( srcb + sourceOffset, width * height * depth * 4 );
+                var dst = new Span< byte >( dstb + destOffset, width * height * depth * 4 );
+                for( var i = 0; i < dst.Length; i++ )
+                    dst[ i ] = (byte)Math.Round( src[ i ] * byte.MaxValue );
+            }
+        }
+
+        /// <inheritdoc />
+        protected override TextureBuffer CreateNew( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            => new R32G32B32A32FTextureBuffer( isDepthConstant, width, height, depth, mipmapAllocations, buffer );
+    }
+}

--- a/src/Lumina/Data/Parsing/Tex/Buffers/R32G32B32A32FTextureBuffer.cs
+++ b/src/Lumina/Data/Parsing/Tex/Buffers/R32G32B32A32FTextureBuffer.cs
@@ -23,8 +23,13 @@ namespace Lumina.Data.Parsing.Tex.Buffers
             {
                 var src = new Span< float >( srcb + sourceOffset, width * height * depth * 4 );
                 var dst = new Span< byte >( dstb + destOffset, width * height * depth * 4 );
-                for( var i = 0; i < dst.Length; i++ )
-                    dst[ i ] = (byte)Math.Round( src[ i ] * byte.MaxValue );
+                for( var i = 0; i < dst.Length; i += 4 )
+                {
+                    dst[ i + 0 ] = (byte)Math.Round( src[ i + 2 ] * byte.MaxValue );
+                    dst[ i + 1 ] = (byte)Math.Round( src[ i + 1 ] * byte.MaxValue );
+                    dst[ i + 2 ] = (byte)Math.Round( src[ i + 0 ] * byte.MaxValue );
+                    dst[ i + 3 ] = (byte)Math.Round( src[ i + 3 ] * byte.MaxValue );
+                }
             }
         }
 

--- a/src/Lumina/Data/Parsing/Tex/Buffers/TextureBuffer.cs
+++ b/src/Lumina/Data/Parsing/Tex/Buffers/TextureBuffer.cs
@@ -1,0 +1,328 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Lumina.Data.Files;
+
+namespace Lumina.Data.Parsing.Tex.Buffers
+{
+    /// <summary>
+    /// Represent a texture in .tex file.
+    /// </summary>
+    public abstract class TextureBuffer
+    {
+        /// <summary>
+        /// Indicates whether this texture is a cube map.
+        /// </summary>
+        public readonly bool IsDepthConstant;
+
+        /// <summary>
+        /// Width of this texture in pixels unit.
+        /// </summary>
+        public readonly int Width;
+
+        /// <summary>
+        /// Height of this texture in pixels unit.
+        /// </summary>
+        public readonly int Height;
+
+        /// <summary>
+        /// Depth of this texture.
+        /// </summary>
+        public readonly int Depth;
+
+        /// <summary>
+        /// Offsets to mipmaps in this texture.
+        /// </summary>
+        public readonly int[] MipmapAllocations;
+
+        /// <summary>
+        /// Raw data.
+        /// </summary>
+        public readonly byte[] RawData;
+
+        /// <summary>
+        /// Number of bytes in this texture.
+        /// </summary>
+        public readonly int NumBytes;
+
+        internal TextureBuffer( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+        {
+            IsDepthConstant = isDepthConstant;
+            Width = width;
+            Height = height;
+            Depth = depth;
+
+            // Test if there are sufficient room for every mipmap in the texture
+            for( var i = 0; i < mipmapAllocations.Length; i++ )
+            {
+                if( mipmapAllocations[ i ] >= NumBytesOfMipmap( i ) )
+                    continue;
+
+                MipmapAllocations = new int[mipmapAllocations.Length];
+                break;
+            }
+
+            if( MipmapAllocations == null )
+            {
+                // Sufficient; use provided params
+
+                MipmapAllocations = mipmapAllocations;
+                NumBytes = mipmapAllocations.Sum();
+                RawData = buffer;
+                if( RawData.Length < NumBytes )
+                    throw new InvalidOperationException( "Buffer size mismatch" );
+            }
+            else
+            {
+                // Insufficient; create a new buffer
+
+                var mipmapSizes = new int[MipmapAllocations.Length];
+                for( var i = 0; i < MipmapAllocations.Length; i++ )
+                {
+                    mipmapSizes[ i ] = NumBytesOfMipmap( i );
+                    MipmapAllocations[ i ] = ( mipmapSizes[ i ] + 3 ) / 4 * 4;
+                }
+
+                NumBytes = MipmapAllocations.Sum();
+                RawData = new byte[NumBytes];
+
+                for( int i = 0, srcOffset = 0, dstOffset = 0;
+                    i < MipmapAllocations.Length;
+                    srcOffset += MipmapAllocations[ i ], dstOffset += mipmapAllocations[ i ], i++ )
+                    Buffer.BlockCopy( buffer, srcOffset, RawData, dstOffset, Math.Min( mipmapSizes[ i ], mipmapAllocations[ i ] ) );
+            }
+        }
+
+        /// <summary>
+        /// Get the width of specified mipmap. Does not check whether mipmapIndex is out of bounds.
+        /// </summary>
+        public int WidthOfMipmap( int mipmapIndex ) => Math.Max( 1, Width >> mipmapIndex );
+
+        /// <summary>
+        /// Get the height of specified mipmap. Does not check whether mipmapIndex is out of bounds.
+        /// </summary>
+        public int HeightOfMipmap( int mipmapIndex ) => Math.Max( 1, Height >> mipmapIndex );
+
+        /// <summary>
+        /// Get the depth of specified mipmap. Does not check whether mipmapIndex is out of bounds.
+        /// </summary>
+        public int DepthOfMipmap( int mipmapIndex ) => IsDepthConstant ? Depth : Math.Max( 1, Depth >> mipmapIndex );
+
+        /// <summary>
+        /// Get the number of pixels of a plane in specified mipmap. Does not check whether mipmapIndex is out of bounds.
+        /// </summary>
+        public int NumPixelsOfMipmapPerPlane( int mipmapIndex ) => WidthOfMipmap( mipmapIndex ) * HeightOfMipmap( mipmapIndex );
+
+        /// <summary>
+        /// Get the number of pixels of specified mipmap. Does not check whether mipmapIndex is out of bounds.
+        /// </summary>
+        public int NumPixelsOfMipmap( int mipmapIndex ) => NumPixelsOfMipmapPerPlane( mipmapIndex ) * DepthOfMipmap( mipmapIndex );
+
+        /// <summary>
+        /// Get the number of bytes of a plane in specified mipmap. Does not check whether mipmapIndex is out of bounds.
+        /// </summary>
+        public abstract int NumBytesOfMipmapPerPlane( int mipmapIndex );
+
+        /// <summary>
+        /// Get the number of bytes of specified mipmap. Does not check whether mipmapIndex is out of bounds.
+        /// </summary>
+        public int NumBytesOfMipmap( int mipmapIndex ) => NumBytesOfMipmapPerPlane( mipmapIndex ) * DepthOfMipmap( mipmapIndex );
+
+        /// <summary>
+        /// Create a new instance of same class.
+        /// </summary>
+        protected abstract TextureBuffer CreateNew( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer );
+
+        /// <summary>
+        /// Convert specified portion of raw data into A8R8G8B8 format.
+        /// </summary>
+        protected abstract void ConvertToB8G8R8A8( byte[] buffer, int destOffset, int sourceOffset, int width, int height, int depth );
+
+        /// <summary>
+        /// Filter out the plane at specified Z.
+        /// </summary>
+        public TextureBuffer Filter( int? mip = null, int? z = null, TexFile.TextureFormat? format = null )
+        {
+            var b8g8r8a8 = false;
+            if( format.HasValue )
+            {
+                if( format.Value == TexFile.TextureFormat.B8G8R8A8 )
+                    b8g8r8a8 = true;
+                else
+                    throw new ArgumentException( $"Unsupported target format {format.Value}", nameof( format ) );
+            }
+
+            if( z == 0 && Depth == 1 )
+                z = 0;
+
+            if( mip == null && MipmapAllocations.Length == 1 )
+                mip = 0;
+
+            if( mip == null )
+            {
+                if( z == null )
+                {
+                    if( format == null )
+                        return this;
+                }
+                else
+                {
+                    if( MipmapAllocations.Length > 1 )
+                        throw new ArgumentException( "Mipmap index must be specified to filter specific Z if when there are multiple mipmaps.", nameof( z ) );
+                    z = 0;
+                }
+            }
+            else
+            {
+                if( mip < 0 || mip >= MipmapAllocations.Length )
+                    throw new ArgumentOutOfRangeException( nameof( mip ) );
+                if( z != null && ( z < 0 || z >= DepthOfMipmap( mip.Value ) ) )
+                    throw new ArgumentOutOfRangeException( nameof( z ) );
+            }
+
+            List< Tuple< int, int, int, int, int, int > > copyList = new();
+            int[] newMipmapAllocations;
+            int newWidth, newHeight, newDepth;
+            if( mip == null )
+            {
+                newMipmapAllocations = new int[MipmapAllocations.Length];
+                newWidth = Width;
+                newHeight = Height;
+                newDepth = Depth;
+                int srcOffset = 0, dstOffset = 0;
+                for( var i = 0; i < newMipmapAllocations.Length; i++ )
+                {
+                    newMipmapAllocations[ i ] = b8g8r8a8 ? 4 * NumPixelsOfMipmap( i ) : NumBytesOfMipmap( i );
+
+                    copyList.Add( new Tuple< int, int, int, int, int, int >(
+                        srcOffset,
+                        dstOffset,
+                        newMipmapAllocations[ i ],
+                        WidthOfMipmap( i ),
+                        HeightOfMipmap( i ),
+                        z == null ? DepthOfMipmap( i ) : 1
+                    ) );
+
+                    newMipmapAllocations[ i ] = ( newMipmapAllocations[ i ] + 3 ) / 4 * 4;
+                    srcOffset += MipmapAllocations[ i ];
+                    dstOffset += newMipmapAllocations[ i ];
+                }
+            }
+            else
+            {
+                newWidth = WidthOfMipmap( mip.Value );
+                newHeight = HeightOfMipmap( mip.Value );
+                newDepth = z == null ? DepthOfMipmap( mip.Value ) : 1;
+
+                if( z == null )
+                    newMipmapAllocations = new[] { b8g8r8a8 ? 4 * NumPixelsOfMipmap( mip.Value ) : NumBytesOfMipmap( mip.Value ) };
+                else
+                    newMipmapAllocations = new[] { b8g8r8a8 ? 4 * NumPixelsOfMipmapPerPlane( mip.Value ) : NumBytesOfMipmapPerPlane( mip.Value ) };
+
+                copyList.Add( new Tuple< int, int, int, int, int, int >(
+                    MipmapAllocations[ ..mip.Value ].Sum() + ( z == null ? 0 : z.Value * NumBytesOfMipmapPerPlane( mip.Value ) ),
+                    0,
+                    newMipmapAllocations[ 0 ],
+                    newWidth,
+                    newHeight,
+                    newDepth
+                ) );
+                newMipmapAllocations[ 0 ] = ( newMipmapAllocations[ 0 ] + 3 ) / 4 * 4;
+            }
+
+            var buffer = new byte[newMipmapAllocations.Sum()];
+            if( b8g8r8a8 )
+            {
+                foreach( var (srcOffset, dstOffset, _, w, h, d) in copyList )
+                    ConvertToB8G8R8A8( buffer, dstOffset, srcOffset, w, h, d );
+
+                return new B8G8R8A8TextureBuffer( z == null && IsDepthConstant, newWidth, newHeight, newDepth, newMipmapAllocations, buffer );
+            }
+            else
+            {
+                foreach( var (srcOffset, dstOffset, dstSize, _, _, _) in copyList )
+                    Buffer.BlockCopy( RawData, srcOffset, buffer, dstOffset, dstSize );
+
+                return CreateNew( z == null && IsDepthConstant, newWidth, newHeight, newDepth, newMipmapAllocations, buffer );
+            }
+        }
+
+        /// <summary>
+        /// Create a new instance of <see cref="TextureBuffer"/>, depending on the specified texture format.
+        /// </summary>
+        public static TextureBuffer FromTextureFormat(
+            TexFile.Attribute attribute,
+            TexFile.TextureFormat format,
+            int width,
+            int height,
+            int depth,
+            int[] mipmapAllocations,
+            byte[] buffer )
+        {
+            var isDepthConstant = false;
+
+            if( ( attribute & TexFile.Attribute.TextureTypeCube ) != 0 )
+            {
+                isDepthConstant = true;
+                depth = 6;
+            }
+
+            switch( format )
+            {
+                // Integer types
+                case TexFile.TextureFormat.L8:
+                    return new L8TextureBuffer( isDepthConstant, width, height, depth, mipmapAllocations, buffer );
+                case TexFile.TextureFormat.A8:
+                    return new A8TextureBuffer( isDepthConstant, width, height, depth, mipmapAllocations, buffer );
+                case TexFile.TextureFormat.B4G4R4A4:
+                    return new B4G4R4A4TextureBuffer( isDepthConstant, width, height, depth, mipmapAllocations, buffer );
+                case TexFile.TextureFormat.B5G5R5A1:
+                    return new B5G5R5A1TextureBuffer( isDepthConstant, width, height, depth, mipmapAllocations, buffer );
+                case TexFile.TextureFormat.B8G8R8A8:
+                    return new B8G8R8A8TextureBuffer( isDepthConstant, width, height, depth, mipmapAllocations, buffer );
+                case TexFile.TextureFormat.B8G8R8X8:
+                    return new B8G8R8X8TextureBuffer( isDepthConstant, width, height, depth, mipmapAllocations, buffer );
+
+                // Floating point types
+                case TexFile.TextureFormat.R16G16B16A16F:
+                    return new R16G16B16A16FTextureBuffer( isDepthConstant, width, height, depth, mipmapAllocations, buffer );
+                case TexFile.TextureFormat.R32G32B32A32F:
+                    return new R32G32B32A32FTextureBuffer( isDepthConstant, width, height, depth, mipmapAllocations, buffer );
+
+                // Block compression types
+                case TexFile.TextureFormat.BC1:
+                case TexFile.TextureFormat.BC2:
+                case TexFile.TextureFormat.BC3:
+                case TexFile.TextureFormat.BC5:
+                case TexFile.TextureFormat.BC7:
+                    return new BlockCompressionTextureBuffer( format, isDepthConstant, width, height, depth, mipmapAllocations, buffer );
+
+                default:
+                    var numBitsPerPixel = 1 << ( (int)( format & TexFile.TextureFormat.BppMask ) >> (int)TexFile.TextureFormat.BppShift );
+                    var numBytesPerPixel = numBitsPerPixel >> 3;
+                    if( numBytesPerPixel == 0 )
+                        throw new NotImplementedException( $"TextureFormat 0x{(int)format:X04} is not supported for image conversion." );
+                    return new UnsupportedTextureBuffer( numBytesPerPixel, isDepthConstant, width, height, depth, mipmapAllocations, buffer );
+            }
+        }
+
+        /// <summary>
+        /// Create a new instance of <see cref="TextureBuffer"/> from a BinaryReader that supports seeking.
+        /// </summary>
+        public static unsafe TextureBuffer FromStream( TexFile.TexHeader header, BinaryReader Reader )
+        {
+            var mipmapAllocations = new int[Math.Min( 13, (int)header.MipLevels )];
+            for( var i = 0; i < mipmapAllocations.Length - 1; i++ )
+                mipmapAllocations[ i ] = (int)( header.OffsetToSurface[ i + 1 ] - header.OffsetToSurface[ i ] );
+            mipmapAllocations[ ^1 ] = (int)( Reader.BaseStream.Length - header.OffsetToSurface[ mipmapAllocations.Length - 1 ] );
+
+            var buffer = new byte[mipmapAllocations.Sum()];
+            Reader.BaseStream.Position = header.OffsetToSurface[ 0 ];
+            // ReSharper disable once MustUseReturnValue
+            Reader.BaseStream.Read( buffer );
+
+            return FromTextureFormat( header.Type, header.Format, header.Width, header.Height, header.Depth, mipmapAllocations, buffer );
+        }
+    }
+}

--- a/src/Lumina/Data/Parsing/Tex/Buffers/TextureBuffer.cs
+++ b/src/Lumina/Data/Parsing/Tex/Buffers/TextureBuffer.cs
@@ -46,7 +46,16 @@ namespace Lumina.Data.Parsing.Tex.Buffers
         /// </summary>
         public readonly int NumBytes;
 
-        internal TextureBuffer( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+        /// <summary>
+        /// Create a new instance of TextureBuffer.
+        /// </summary>
+        /// <param name="isDepthConstant">Specify whether the secondary mipmap and later get lesser number of depth.</param>
+        /// <param name="width">Width of the primary mipmap.</param>
+        /// <param name="height">Height of the primary mipmap.</param>
+        /// <param name="depth">Depth of the primary mipmap.</param>
+        /// <param name="mipmapAllocations">Number of bytes allocated for each mipmap.</param>
+        /// <param name="buffer">Byte array containing multiple mipmaps, one right after another allocation.</param>
+        protected TextureBuffer( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
         {
             IsDepthConstant = isDepthConstant;
             Width = width;

--- a/src/Lumina/Data/Parsing/Tex/Buffers/UnsupportedTextureBuffer.cs
+++ b/src/Lumina/Data/Parsing/Tex/Buffers/UnsupportedTextureBuffer.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Lumina.Data.Parsing.Tex.Buffers
+{
+    /// <summary>
+    /// Represent a face in .tex file, in B8G8R8A8 texture format.
+    /// </summary>
+    public class UnsupportedTextureBuffer : TextureBuffer
+    {
+        private readonly int _numBytesPerPixel;
+
+        /// <inheritdoc />
+        public UnsupportedTextureBuffer( int numBytesPerPixel, bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            : base( isDepthConstant, width, height, depth, mipmapAllocations, buffer )
+        {
+            _numBytesPerPixel = numBytesPerPixel;
+        }
+
+        /// <inheritdoc />
+        public override int NumBytesOfMipmapPerPlane( int mipmapIndex ) => NumPixelsOfMipmapPerPlane( mipmapIndex ) * _numBytesPerPixel;
+
+        /// <inheritdoc />
+        protected override void ConvertToB8G8R8A8( byte[] buffer, int destOffset, int sourceOffset, int width, int height, int depth )
+            => throw new NotSupportedException( "Decoding this texture format is currently not supported." );
+
+        /// <inheritdoc />
+        protected override TextureBuffer CreateNew( bool isDepthConstant, int width, int height, int depth, int[] mipmapAllocations, byte[] buffer )
+            => new UnsupportedTextureBuffer( _numBytesPerPixel, isDepthConstant, width, height, depth, mipmapAllocations, buffer );
+    }
+}

--- a/src/Lumina/Data/Parsing/Tex/Flags.cs
+++ b/src/Lumina/Data/Parsing/Tex/Flags.cs
@@ -7,6 +7,11 @@ namespace Lumina.Data.Parsing.Tex
     public enum SquishOptions
     {
         /// <summary>
+        /// No option.
+        /// </summary>
+        None = 0,
+        
+        /// <summary>
         /// Use DXT1 compression.
         /// </summary>
         DXT1 = ( 1 << 0 ),


### PR DESCRIPTION
Cube maps are treated as having depth value of 6. 

### Usage
```cs
// t1, t2, t3, and t4 effectively does the same, but the last one should be quickest.
var t1 = GetFile<TexFile>("common/graphics/texture/-caustics.tex")!.TextureBuffer.Filter(mip: 0).Filter(z: 2).Filter(format: TexFile.TextureFormat.B8G8R8A8).RawData;
var t2 = GetFile<TexFile>("common/graphics/texture/-caustics.tex")!.TextureBuffer.Filter(mip: 0, z: 2).Filter(format: TexFile.TextureFormat.B8G8R8A8).RawData;
var t3 = GetFile<TexFile>("common/graphics/texture/-caustics.tex")!.TextureBuffer.Filter(mip: 0, format: TexFile.TextureFormat.B8G8R8A8).Filter(z: 2).RawData;
var t4 = GetFile<TexFile>("common/graphics/texture/-caustics.tex")!.TextureBuffer.Filter(mip: 0, z: 2, format: TexFile.TextureFormat.B8G8R8A8).RawData;

// t5 and t6 do the same thing, except that ImageData will cache the result.
var t5 = GetFile<TexFile>("common/graphics/texture/-omni_shadow_index_table.tex").ImageData;
var t6 = GetFile<TexFile>("common/graphics/texture/-omni_shadow_index_table.tex").Filter(mip: 0, z: 0, format: TexFile.TextureFormat.B8G8R8A8).RawData;
```

### Example
Export all planes to png files.
```cs
foreach( var (_, repo) in gameData.Repositories )
{
    foreach( var (_, cats) in repo.Categories )
    {
        foreach( var cat in cats )
        {
            Console.WriteLine( "Current category: {0:X02}{1:X02}{2:X02} ({3} files)", cat.CategoryId, cat.Expansion, cat.Chunk,
                cat.IndexHashTableEntries.Count );
            var dirName = $"Z:\\rd\\{cat.CategoryId:X02}{cat.Expansion:X02}{cat.Chunk:X02}";
            Directory.CreateDirectory( dirName );

            foreach( var (_, entry) in cat.IndexHashTableEntries )
            {
                if( cat.DatFiles[ entry.DataFileId ].GetFileMetadata( entry.Offset ).Type != FileType.Texture )
                    continue;

                var tf = cat.GetFile< TexFile >( entry.DataFileId, entry.Offset )!.TextureBuffer.Filter( format: TexFile.TextureFormat.B8G8R8A8 );

                for( var i = 0; i < tf.MipmapAllocations.Length; i++ )
                {
                    var p = tf.Filter( i );
                    for( int j = 0, j_ = p.Depth; j < j_; j++ )
                    {
                        var p2 = p.Filter( 0, j );
                        unsafe
                        {
                            fixed( byte* x = p2.RawData )
                            {
                                var bmp = new Bitmap( p2.Width, p2.Height, p2.Width * 4, PixelFormat.Format32bppArgb, (IntPtr)x );
                                bmp.Save( $"{dirName}\\{entry.DataFileId}.{entry.Offset:X08}.{i}.{j}.png", ImageFormat.Png );
                            }
                        }
                    }
                }
            }
        }
    }
}
```
