### PR TITLE
Add LuminaOption.LoadMultithreaded, and load repo/categories in parallel

### DIFF
--- a/src/Lumina/GameData.cs
+++ b/src/Lumina/GameData.cs
@@ -81,9 +81,8 @@ namespace Lumina
 
             if( options?.LoadMultithreaded == true )
             {
-                Repositories = Task.WhenAll(
-                    DataPath.GetDirectories()
-                        .Select( repo => Task.Run( () => new Repository( repo, this ) ) ) )
+                var repoTasks = DataPath.GetDirectories().Select( repo => Task.Run( () => new Repository( repo, this ) ) );
+                Repositories = Task.WhenAll( repoTasks )
                     .GetAwaiter()
                     .GetResult()
                     .ToDictionary( x => x.Name.ToLowerInvariant(), x => x );

--- a/src/Lumina/LuminaOptions.cs
+++ b/src/Lumina/LuminaOptions.cs
@@ -39,5 +39,10 @@ namespace Lumina
         /// Whether or not known RSV values in sheets should be resolved when loading sheets
         /// </summary>
         public bool ResolveKnownRsvSheetValues { get; set; } = true;
+
+        /// <summary>
+        /// If enabled, resources will be loaded using multiple threads.
+        /// </summary>
+        public bool LoadMultithreaded { get; set; } = false;
     }
 }


### PR DESCRIPTION
## Example code
* Parallel attempt takes 4.145s. (130ms/attempt)
* Non-parallel attempt takes 15.630s. (488ms/attempt)

```cs
Stopwatch stopwatch;

stopwatch = Stopwatch.StartNew();
for( var i = 0; i < 32; i++ )
    _ = new GameData( args[ 0 ], new LuminaOptions { LoadMultithreaded = true } );
stopwatch.Stop();
Console.WriteLine( stopwatch.ElapsedMilliseconds );

stopwatch = Stopwatch.StartNew();
for( var i = 0; i < 32; i++ )
    _ = new GameData( args[ 0 ], new LuminaOptions { LoadMultithreaded = false } );
stopwatch.Stop();
Console.WriteLine( stopwatch.ElapsedMilliseconds );
```