### PR TITLE
Add scd file reading support

### DIFF
--- a/src/Lumina/Data/Files/ScdFile.cs
+++ b/src/Lumina/Data/Files/ScdFile.cs
@@ -11,24 +11,24 @@ namespace Lumina.Data.Files
     {
         public class Sound
         {
-            public ScdSound.SoundBasicDesc SoundBasicDesc;
-            public ScdSound.RoutingInfo? RoutingInfo;
-            public ScdSound.SendInfo[]? SendInfos;
-            public ScdSound.SoundEffectParam? SoundEffectParam;
-            public ScdSound.BusDuckingInfo? BusDuckingInfo;
-            public ScdSound.AccelerationInfo? AccelerationInfo;
-            public ScdSound.AtomosgearInfo? AtomosgearInfo;
-            public ScdSound.SoundExtraDesc? SoundExtraDesc;
+            public SoundBasicDesc SoundBasicDesc;
+            public RoutingInfo? RoutingInfo;
+            public SendInfo[]? SendInfos;
+            public SoundEffectParam? SoundEffectParam;
+            public BusDuckingInfo? BusDuckingInfo;
+            public AccelerationInfo? AccelerationInfo;
+            public AtomosgearInfo? AtomosgearInfo;
+            public SoundExtraDesc? SoundExtraDesc;
 
             public object TrackInfos;
-            public ScdSound.CycleInfo? CycleInfo;
+            public CycleInfo? CycleInfo;
         }
 
         public class Audio
         {
-            public ScdAudio.AudioBasicDesc AudioBasicDesc;
+            public AudioBasicDesc AudioBasicDesc;
 
-            public ScdAudio.SubInfoMarkerChunk? MarkerChunkHeader;
+            public SubInfoMarkerChunk? MarkerChunkHeader;
             public uint[]? Markers;
 
             public object? AudioDataHeader;
@@ -70,8 +70,8 @@ namespace Lumina.Data.Files
 
         public override void LoadFile()
         {
-            var header = new ScdCommon.BinaryHeader( Reader );
-            var scdHeader = Reader.ReadStructure< ScdCommon.ScdHeader >();
+            var header = new BinaryHeader( Reader );
+            var scdHeader = Reader.ReadStructure< ScdHeader >();
 
             _soundOffsets = new uint[ scdHeader.SoundCount ];
             for( var i = 0; i < scdHeader.SoundCount; i++ )
@@ -112,290 +112,290 @@ namespace Lumina.Data.Files
         public Sound GetSound( int index )
         {
             Reader.Position = _soundOffsets[ index ];
-            var soundBasicDesc = Reader.ReadStructure< ScdSound.SoundBasicDesc >();
+            var soundBasicDesc = Reader.ReadStructure< SoundBasicDesc >();
 
             var sound = new Sound();
             sound.SoundBasicDesc = soundBasicDesc;
 
-            if( soundBasicDesc.Attribute.HasFlag( ScdSound.SoundAttribute.ExistRoutingSetting ) )
+            if( soundBasicDesc.Attribute.HasFlag( SoundAttribute.ExistRoutingSetting ) )
             {
-                var routingInfo = Reader.ReadStructure< ScdSound.RoutingInfo >();
+                var routingInfo = Reader.ReadStructure< RoutingInfo >();
                 sound.RoutingInfo = routingInfo;
-                sound.SendInfos = Reader.ReadStructuresAsArray< ScdSound.SendInfo >( routingInfo.SendCount );
-                sound.SoundEffectParam = Reader.ReadStructure< ScdSound.SoundEffectParam >();
+                sound.SendInfos = Reader.ReadStructuresAsArray< SendInfo >( routingInfo.SendCount );
+                sound.SoundEffectParam = Reader.ReadStructure< SoundEffectParam >();
             }
 
-            if( soundBasicDesc.Attribute.HasFlag( ScdSound.SoundAttribute.BusDucking ) )
+            if( soundBasicDesc.Attribute.HasFlag( SoundAttribute.BusDucking ) )
             {
-                sound.BusDuckingInfo = Reader.ReadStructure< ScdSound.BusDuckingInfo >();
+                sound.BusDuckingInfo = Reader.ReadStructure< BusDuckingInfo >();
             }
 
-            if( soundBasicDesc.Attribute.HasFlag( ScdSound.SoundAttribute.Acceleration ) )
+            if( soundBasicDesc.Attribute.HasFlag( SoundAttribute.Acceleration ) )
             {
-                sound.AccelerationInfo = new ScdSound.AccelerationInfo( Reader );
+                sound.AccelerationInfo = new AccelerationInfo( Reader );
             }
 
-            if( soundBasicDesc.Attribute.HasFlag( ScdSound.SoundAttribute.Atomosgear ) )
+            if( soundBasicDesc.Attribute.HasFlag( SoundAttribute.Atomosgear ) )
             {
-                sound.AtomosgearInfo = Reader.ReadStructure< ScdSound.AtomosgearInfo >();
+                sound.AtomosgearInfo = Reader.ReadStructure< AtomosgearInfo >();
             }
 
-            if( soundBasicDesc.Attribute.HasFlag( ScdSound.SoundAttribute.ExtraDesc ) )
+            if( soundBasicDesc.Attribute.HasFlag( SoundAttribute.ExtraDesc ) )
             {
-                sound.SoundExtraDesc = Reader.ReadStructure< ScdSound.SoundExtraDesc >();
+                sound.SoundExtraDesc = Reader.ReadStructure< SoundExtraDesc >();
             }
 
-            if( soundBasicDesc.Type is ScdSound.SoundType.Random or ScdSound.SoundType.Cycle or ScdSound.SoundType.GroupRandom )
+            if( soundBasicDesc.Type is SoundType.Random or SoundType.Cycle or SoundType.GroupRandom )
             {
-                sound.TrackInfos = Reader.ReadStructures< ScdSound.RandomTrackInfo >( soundBasicDesc.TrackCount );
+                sound.TrackInfos = Reader.ReadStructures< RandomTrackInfo >( soundBasicDesc.TrackCount );
 
-                if( soundBasicDesc.Type == ScdSound.SoundType.Cycle )
+                if( soundBasicDesc.Type == SoundType.Cycle )
                 {
-                    sound.CycleInfo = Reader.ReadStructure< ScdSound.CycleInfo >();
+                    sound.CycleInfo = Reader.ReadStructure< CycleInfo >();
                 }
             }
             else
             {
-                sound.TrackInfos = Reader.ReadStructures< ScdSound.TrackInfo >( soundBasicDesc.TrackCount );
+                sound.TrackInfos = Reader.ReadStructures< TrackInfo >( soundBasicDesc.TrackCount );
             }
 
             return sound;
         }
 
         // Just a prototype, don't use it.
-        public List< ( ScdTrack.TrackCmd cmd, object? data ) > GetTrack( int index )
+        public List< ( TrackCmd cmd, object? data ) > GetTrack( int index )
         {
             Reader.Position = _trackOffsets[ index ];
-            var trackCmdData = new List< (ScdTrack.TrackCmd, object?) >();
+            var trackCmdData = new List< (TrackCmd, object?) >();
 
             while( true )
             {
-                var cmd = (ScdTrack.TrackCmd)Reader.ReadUInt16();
+                var cmd = (TrackCmd)Reader.ReadUInt16();
                 object? data = null;
 
                 switch( cmd )
                 {
-                    case ScdTrack.TrackCmd.End:
+                    case TrackCmd.End:
                         trackCmdData.Add( ( cmd, null ) );
                         return trackCmdData;
 
-                    case ScdTrack.TrackCmd.Volume:
-                        data = Reader.ReadStructure< ScdTrack.TrackCmdParam >();
+                    case TrackCmd.Volume:
+                        data = Reader.ReadStructure< TrackCmdParam >();
                         break;
 
-                    case ScdTrack.TrackCmd.Pitch:
-                        data = Reader.ReadStructure< ScdTrack.TrackCmdParam >();
+                    case TrackCmd.Pitch:
+                        data = Reader.ReadStructure< TrackCmdParam >();
                         break;
 
-                    case ScdTrack.TrackCmd.Interval:
+                    case TrackCmd.Interval:
                         data = Reader.ReadUInt32();
                         break;
 
-                    case ScdTrack.TrackCmd.Modulation:
-                        data = Reader.ReadStructure< ScdTrack.ModulationCmdParam >();
+                    case TrackCmd.Modulation:
+                        data = Reader.ReadStructure< ModulationCmdParam >();
                         break;
 
-                    case ScdTrack.TrackCmd.ReleaseRate:
+                    case TrackCmd.ReleaseRate:
                         data = Reader.ReadUInt32();
                         break;
 
-                    case ScdTrack.TrackCmd.Panning:
-                        data = Reader.ReadStructure< ScdTrack.TrackCmdParam >();
+                    case TrackCmd.Panning:
+                        data = Reader.ReadStructure< TrackCmdParam >();
                         break;
 
-                    case ScdTrack.TrackCmd.KeyOn:
+                    case TrackCmd.KeyOn:
                         break;
 
-                    case ScdTrack.TrackCmd.RandomVolume:
-                        data = Reader.ReadStructure< ScdTrack.RandomCmdParam >();
+                    case TrackCmd.RandomVolume:
+                        data = Reader.ReadStructure< RandomCmdParam >();
                         break;
 
-                    case ScdTrack.TrackCmd.RandomPitch:
-                        data = Reader.ReadStructure< ScdTrack.RandomCmdParam >();
+                    case TrackCmd.RandomPitch:
+                        data = Reader.ReadStructure< RandomCmdParam >();
                         break;
 
-                    case ScdTrack.TrackCmd.RandomPan:
-                        data = Reader.ReadStructure< ScdTrack.RandomCmdParam >();
+                    case TrackCmd.RandomPan:
+                        data = Reader.ReadStructure< RandomCmdParam >();
                         break;
 
-                    case ScdTrack.TrackCmd.KeyOff:
+                    case TrackCmd.KeyOff:
                         break;
 
-                    case ScdTrack.TrackCmd.LoopStart:
+                    case TrackCmd.LoopStart:
                         data = Reader.ReadUInt32Array( 2 ); // loopLowerCnt, loopUpperCnt
                         break;
 
-                    case ScdTrack.TrackCmd.LoopEnd:
+                    case TrackCmd.LoopEnd:
                         break;
 
-                    case ScdTrack.TrackCmd.ExternalAudio:
-                        data = new ScdTrack.ExternalAudioInfo( Reader );
+                    case TrackCmd.ExternalAudio:
+                        data = new ExternalAudioInfo( Reader );
                         break;
 
-                    case ScdTrack.TrackCmd.EndForLoop:
+                    case TrackCmd.EndForLoop:
                         trackCmdData.Add( ( cmd, null ) );
                         return trackCmdData;
 
-                    case ScdTrack.TrackCmd.AddInterval:
+                    case TrackCmd.AddInterval:
                         data = Reader.ReadSingle();
                         break;
 
-                    case ScdTrack.TrackCmd.Expression:
+                    case TrackCmd.Expression:
                         data = Reader.ReadSingleArray( 2 ); // lowerExpression, upperExpression
                         break;
 
-                    case ScdTrack.TrackCmd.Velocity:
+                    case TrackCmd.Velocity:
                         data = Reader.ReadSingle();
                         break;
 
-                    case ScdTrack.TrackCmd.MidiVolume:
+                    case TrackCmd.MidiVolume:
                         data = Reader.ReadSingleArray( 2 ); // lowerVolume, upperVolume
                         break;
 
-                    case ScdTrack.TrackCmd.MidiAddVolume:
+                    case TrackCmd.MidiAddVolume:
                         data = Reader.ReadSingle();
                         break;
 
-                    case ScdTrack.TrackCmd.MidiPan:
+                    case TrackCmd.MidiPan:
                         data = Reader.ReadSingleArray( 2 ); // lowerPan, upperPan
                         break;
 
-                    case ScdTrack.TrackCmd.MidiAddPan:
+                    case TrackCmd.MidiAddPan:
                         data = Reader.ReadSingle();
                         break;
 
-                    case ScdTrack.TrackCmd.ModulationType:
-                        data = ( (ScdTrack.OscillatorCarrier)Reader.ReadUInt32(), (ScdTrack.OscillatorMode)Reader.ReadUInt32() );
+                    case TrackCmd.ModulationType:
+                        data = ( (OscillatorCarrier)Reader.ReadUInt32(), (OscillatorMode)Reader.ReadUInt32() );
                         break;
 
-                    case ScdTrack.TrackCmd.ModulationDepth:
-                        data = new ScdTrack.ModulationDepth
+                    case TrackCmd.ModulationDepth:
+                        data = new ModulationDepth
                         {
                             Carrier = Reader.ReadUInt32(),
                             Depth = Reader.ReadSingle()
                         };
                         break;
 
-                    case ScdTrack.TrackCmd.ModulationAddDepth:
-                        data = new ScdTrack.ModulationDepth
+                    case TrackCmd.ModulationAddDepth:
+                        data = new ModulationDepth
                         {
                             Carrier = Reader.ReadUInt32(),
                             Depth = Reader.ReadSingle()
                         };
                         break;
 
-                    case ScdTrack.TrackCmd.ModulationSpeed:
-                        data = new ScdTrack.ModulationSpeed
+                    case TrackCmd.ModulationSpeed:
+                        data = new ModulationSpeed
                         {
                             Carrier = Reader.ReadUInt32(),
                             Speed = Reader.ReadUInt32()
                         };
                         break;
 
-                    case ScdTrack.TrackCmd.ModulationAddSpeed:
-                        data = new ScdTrack.ModulationSpeed
+                    case TrackCmd.ModulationAddSpeed:
+                        data = new ModulationSpeed
                         {
                             Carrier = Reader.ReadUInt32(),
                             Speed = Reader.ReadUInt32()
                         };
                         break;
 
-                    case ScdTrack.TrackCmd.ModulationOff:
-                        data = (ScdTrack.OscillatorCarrier)Reader.ReadUInt32();
+                    case TrackCmd.ModulationOff:
+                        data = (OscillatorCarrier)Reader.ReadUInt32();
                         break;
 
-                    case ScdTrack.TrackCmd.PitchBend:
+                    case TrackCmd.PitchBend:
                         data = Reader.ReadSingleArray( 2 ); // lowerPitch, upperPitch
                         break;
 
-                    case ScdTrack.TrackCmd.Transpose:
+                    case TrackCmd.Transpose:
                         data = Reader.ReadSingleArray( 2 ); // lowerPitch, upperPitch
                         break;
 
-                    case ScdTrack.TrackCmd.AddTranspose:
+                    case TrackCmd.AddTranspose:
                         data = Reader.ReadSingle();
                         break;
 
-                    case ScdTrack.TrackCmd.FrPanning:
-                        data = Reader.ReadStructure< ScdTrack.TrackCmdParam >();
+                    case TrackCmd.FrPanning:
+                        data = Reader.ReadStructure< TrackCmdParam >();
                         break;
 
-                    case ScdTrack.TrackCmd.RandomWait:
+                    case TrackCmd.RandomWait:
                         data = Reader.ReadUInt32Array( 2 ); // lowerWait, upperWait
                         break;
 
-                    case ScdTrack.TrackCmd.Adsr:
-                        data = Reader.ReadStructure< ScdTrack.TrackCmdParam >();
+                    case TrackCmd.Adsr:
+                        data = Reader.ReadStructure< TrackCmdParam >();
                         break;
 
-                    case ScdTrack.TrackCmd.CutOff:
+                    case TrackCmd.CutOff:
                         break;
 
-                    case ScdTrack.TrackCmd.Jump:
-                        data = ( (ScdTrack.TrackCmdJump)Reader.ReadUInt32(), Reader.ReadInt32() ); // condition, offset
+                    case TrackCmd.Jump:
+                        data = ( (TrackCmdJump)Reader.ReadUInt32(), Reader.ReadInt32() ); // condition, offset
                         break;
 
-                    case ScdTrack.TrackCmd.PlayContinueLoop:
+                    case TrackCmd.PlayContinueLoop:
                         break;
 
-                    case ScdTrack.TrackCmd.Sweep:
+                    case TrackCmd.Sweep:
                         data = ( Reader.ReadSingle(), Reader.ReadUInt32() ); // pitch, time
                         break;
 
-                    case ScdTrack.TrackCmd.MidiKeyOnOld:
+                    case TrackCmd.MidiKeyOnOld:
                         break;
 
-                    case ScdTrack.TrackCmd.SlurOn:
+                    case TrackCmd.SlurOn:
                         break;
 
-                    case ScdTrack.TrackCmd.SlurOff:
+                    case TrackCmd.SlurOff:
                         break;
 
-                    case ScdTrack.TrackCmd.AutoAdsrEnvelope:
-                        data = Reader.ReadStructure< ScdTrack.AutoAdsrEnvelope >();
+                    case TrackCmd.AutoAdsrEnvelope:
+                        data = Reader.ReadStructure< AutoAdsrEnvelope >();
                         break;
 
-                    case ScdTrack.TrackCmd.MidiExternalAudio:
-                        data = new ScdTrack.ExternalAudioInfo( Reader );
+                    case TrackCmd.MidiExternalAudio:
+                        data = new ExternalAudioInfo( Reader );
                         break;
 
-                    case ScdTrack.TrackCmd.Marker:
+                    case TrackCmd.Marker:
                         break;
 
-                    case ScdTrack.TrackCmd.InitParams:
+                    case TrackCmd.InitParams:
                         break;
 
-                    case ScdTrack.TrackCmd.Version:
+                    case TrackCmd.Version:
                         data = Reader.ReadUInt16();
                         break;
 
-                    case ScdTrack.TrackCmd.ReverbOn:
+                    case TrackCmd.ReverbOn:
                         data = Reader.ReadSingle(); // reverbDryVolume
                         break;
 
-                    case ScdTrack.TrackCmd.ReverbOff:
+                    case TrackCmd.ReverbOff:
                         break;
 
-                    case ScdTrack.TrackCmd.MidiKeyOn:
+                    case TrackCmd.MidiKeyOn:
                         data = Reader.ReadSingleArray( 2 ); // velocity, pitch
                         break;
 
-                    case ScdTrack.TrackCmd.PortamentoOn:
+                    case TrackCmd.PortamentoOn:
                         data = ( Reader.ReadInt32(), Reader.ReadSingle() ); // portamentoTime, pitch
                         break;
 
-                    case ScdTrack.TrackCmd.PortamentoOff:
+                    case TrackCmd.PortamentoOff:
                         break;
 
-                    case ScdTrack.TrackCmd.MidiEnd:
+                    case TrackCmd.MidiEnd:
                         trackCmdData.Add( ( cmd, null ) );
                         return trackCmdData;
 
-                    case ScdTrack.TrackCmd.ClearKeyInfo:
+                    case TrackCmd.ClearKeyInfo:
                         break;
 
-                    case ScdTrack.TrackCmd.ModulationDepthFade:
-                        data = new ScdTrack.ModulationDepth
+                    case TrackCmd.ModulationDepthFade:
+                        data = new ModulationDepth
                         {
                             Carrier = Reader.ReadUInt32(),
                             Depth = Reader.ReadSingle(),
@@ -403,8 +403,8 @@ namespace Lumina.Data.Files
                         };
                         break;
 
-                    case ScdTrack.TrackCmd.ModulationSpeedFade:
-                        data = new ScdTrack.ModulationSpeed
+                    case TrackCmd.ModulationSpeedFade:
+                        data = new ModulationSpeed
                         {
                             Carrier = Reader.ReadUInt32(),
                             Speed = Reader.ReadUInt32(),
@@ -412,22 +412,22 @@ namespace Lumina.Data.Files
                         };
                         break;
 
-                    case ScdTrack.TrackCmd.AnalysisFlag:
+                    case TrackCmd.AnalysisFlag:
                         data = Reader.ReadUInt16Array( Reader.ReadUInt16() );
                         break;
 
-                    case ScdTrack.TrackCmd.Config:
-                        var trackConfig = new ScdTrack.TrackConfig
+                    case TrackCmd.Config:
+                        var trackConfig = new TrackConfig
                         {
-                            Type = (ScdTrack.TrackCmdConfigType)Reader.ReadUInt16(),
+                            Type = (TrackCmdConfigType)Reader.ReadUInt16(),
                             Count = Reader.ReadUInt16()
                         };
 
-                        if( trackConfig.Type == ScdTrack.TrackCmdConfigType.IntervalTypeFloat )
+                        if( trackConfig.Type == TrackCmdConfigType.IntervalTypeFloat )
                         {
                             trackConfig.Data = Reader.ReadUInt16() != 0;
                         }
-                        else if( trackConfig.Type > ScdTrack.TrackCmdConfigType.IntervalTypeFloat )
+                        else if( trackConfig.Type > TrackCmdConfigType.IntervalTypeFloat )
                         {
                             trackConfig.Data = Reader.ReadUInt16Array( trackConfig.Count );
                         }
@@ -435,39 +435,39 @@ namespace Lumina.Data.Files
                         data = trackConfig;
                         break;
 
-                    case ScdTrack.TrackCmd.Filter:
-                        data = Reader.ReadStructure< ScdTrack.TrackFilter >();
+                    case TrackCmd.Filter:
+                        data = Reader.ReadStructure< TrackFilter >();
                         break;
 
-                    case ScdTrack.TrackCmd.PlayInnerSound:
+                    case TrackCmd.PlayInnerSound:
                         data = Reader.ReadUInt16Array( 2 ); // bankNumber, soundIndex
                         break;
 
-                    case ScdTrack.TrackCmd.VolumeZeroOne:
-                        var zeroOneHeader = Reader.ReadStructure< ScdTrack.TrackZeroOneParamHeader >();
-                        data = Reader.ReadStructuresAsArray< ScdTrack.TrackZeroOnePoint >( zeroOneHeader.NumPoints );
+                    case TrackCmd.VolumeZeroOne:
+                        var zeroOneHeader = Reader.ReadStructure< TrackZeroOneParamHeader >();
+                        data = Reader.ReadStructuresAsArray< TrackZeroOnePoint >( zeroOneHeader.NumPoints );
                         break;
 
-                    case ScdTrack.TrackCmd.ZeroOneJump:
+                    case TrackCmd.ZeroOneJump:
                         data = Reader.ReadInt32(); // jumpTarget
                         break;
 
-                    case ScdTrack.TrackCmd.ChannelVolumeZeroOne:
-                        var channelZeroOneHeader = Reader.ReadStructure< ScdTrack.TrackChannelZeroOneParamHeader >();
-                        var zeroOnePoints = new ScdTrack.TrackZeroOnePoint[ channelZeroOneHeader.NumChannels ][];
+                    case TrackCmd.ChannelVolumeZeroOne:
+                        var channelZeroOneHeader = Reader.ReadStructure< TrackChannelZeroOneParamHeader >();
+                        var zeroOnePoints = new TrackZeroOnePoint[ channelZeroOneHeader.NumChannels ][];
 
                         for( var i = 0; i < channelZeroOneHeader.NumChannels; i++ )
                         {
-                            var zeroOneParamHeader = Reader.ReadStructure< ScdTrack.TrackZeroOneParamHeader >();
-                            zeroOnePoints[ i ] = Reader.ReadStructuresAsArray< ScdTrack.TrackZeroOnePoint >( zeroOneParamHeader.NumPoints );
+                            var zeroOneParamHeader = Reader.ReadStructure< TrackZeroOneParamHeader >();
+                            zeroOnePoints[ i ] = Reader.ReadStructuresAsArray< TrackZeroOnePoint >( zeroOneParamHeader.NumPoints );
                         }
 
                         data = zeroOnePoints;
                         break;
 
-                    case ScdTrack.TrackCmd.Unknown64:
-                        var unknownHeader = Reader.ReadStructure< ScdTrack.TrackUnknown64Header >();
-                        data = Reader.ReadStructures< ScdTrack.TrackUnknown64 >( unknownHeader.Count );
+                    case TrackCmd.Unknown64:
+                        var unknownHeader = Reader.ReadStructure< TrackUnknown64Header >();
+                        data = Reader.ReadStructures< TrackUnknown64 >( unknownHeader.Count );
                         break;
 
                     default:
@@ -487,15 +487,15 @@ namespace Lumina.Data.Files
         public Audio GetAudio( int index )
         {
             Reader.Position = _audioOffsets[ index ];
-            var audioBasicDesc = Reader.ReadStructure< ScdAudio.AudioBasicDesc >();
+            var audioBasicDesc = Reader.ReadStructure< AudioBasicDesc >();
 
             var audio = new Audio();
             audio.AudioBasicDesc = audioBasicDesc;
 
             var subInfoStartPos = Reader.Position;
-            if( audioBasicDesc.Flg.HasFlag( ScdAudio.AudioFlag.MarkerChunk ) )
+            if( audioBasicDesc.Flg.HasFlag( AudioFlag.MarkerChunk ) )
             {
-                var subInfoMarkerChunk = Reader.ReadStructure< ScdAudio.SubInfoMarkerChunk >();
+                var subInfoMarkerChunk = Reader.ReadStructure< SubInfoMarkerChunk >();
                 audio.MarkerChunkHeader = subInfoMarkerChunk;
                 audio.Markers = Reader.ReadUInt32Array( subInfoMarkerChunk.NumMarkers );
 
@@ -504,13 +504,13 @@ namespace Lumina.Data.Files
 
             switch( audioBasicDesc.Format )
             {
-                case ScdAudio.AudioFormat.Empty:
+                case AudioFormat.Empty:
                     audio.AudioData = Array.Empty< byte >();
                     break;
 
-                case ScdAudio.AudioFormat.OggVorbis:
+                case AudioFormat.OggVorbis:
                 {
-                    var oggSeekTableHeader = Reader.ReadStructure< ScdAudio.OggVorbisSeekTableHeader >();
+                    var oggSeekTableHeader = Reader.ReadStructure< OggVorbisSeekTableHeader >();
                     audio.AudioDataHeader = oggSeekTableHeader;
                     audio.SeekTable = Reader.ReadUInt32Array( (int)( oggSeekTableHeader.SeekTableSize / 4 ) );
 
@@ -546,11 +546,11 @@ namespace Lumina.Data.Files
                     break;
                 }
 
-                case ScdAudio.AudioFormat.Mp3:
+                case AudioFormat.Mp3:
                     var id = Reader.PeekBytes( 4 );
                     if( id[ 0 ] == 'S' && id[ 1 ] == 'T' && id[ 2 ] == 'B' && id[ 3 ] == 'L' )
                     {
-                        var mp3SeekTableHeader = Reader.ReadStructure< ScdAudio.PS3MP3SeekTableHeader >();
+                        var mp3SeekTableHeader = Reader.ReadStructure< PS3MP3SeekTableHeader >();
                         audio.AudioDataHeader = mp3SeekTableHeader;
                         audio.SeekTable = Reader.ReadUInt32Array( mp3SeekTableHeader.NumElement );
                     }
@@ -564,19 +564,19 @@ namespace Lumina.Data.Files
                     audio.AudioData = Reader.ReadBytes( (int)audioBasicDesc.Size );
                     break;
 
-                case ScdAudio.AudioFormat.MsAdpcm:
-                    audio.AudioDataHeader = Reader.ReadStructure< ScdAudio.AdpcmWaveFormat >();
+                case AudioFormat.MsAdpcm:
+                    audio.AudioDataHeader = Reader.ReadStructure< AdpcmWaveFormat >();
                     Reader.Position = subInfoStartPos + audioBasicDesc.SubInfoSize;
                     audio.AudioData = Reader.ReadBytes( (int)audioBasicDesc.Size );
                     break;
 
-                case ScdAudio.AudioFormat.Atrac9:
-                    audio.AudioDataHeader = Reader.ReadStructure< ScdAudio.ATRAC9Header >();
+                case AudioFormat.Atrac9:
+                    audio.AudioDataHeader = Reader.ReadStructure< ATRAC9Header >();
                     Reader.Position = subInfoStartPos + audioBasicDesc.SubInfoSize;
                     audio.AudioData = Reader.ReadBytes( (int)audioBasicDesc.Size );
                     break;
 
-                case (ScdAudio.AudioFormat)5: // headerless Atrac3 stream?
+                case (AudioFormat)5: // headerless Atrac3 stream?
                 default:
                     System.Diagnostics.Debug.WriteLine( "Unknown audio format type id " + audioBasicDesc.Format );
 
@@ -589,23 +589,23 @@ namespace Lumina.Data.Files
         }
 
         /// <summary>Parses the layout data.</summary>
-        public ScdLayout.SoundObject? GetLayout()
+        public SoundObject? GetLayout()
         {
             if( _layoutOffset == 0 )
                 return null;
 
             Reader.BaseStream.Position = _layoutOffset;
-            return new ScdLayout.SoundObject( Reader );
+            return new SoundObject( Reader );
         }
 
         /// <summary>Parses the attribute data.</summary>
-        public ScdAttribute.AttributeData? GetAttributeData()
+        public AttributeData? GetAttributeData()
         {
             if( _attributeOffset == 0 )
                 return null;
 
             Reader.Position = _attributeOffset;
-            return new ScdAttribute.AttributeData( Reader );
+            return new AttributeData( Reader );
         }
     }
 }

--- a/src/Lumina/Data/Files/ScdFile.cs
+++ b/src/Lumina/Data/Files/ScdFile.cs
@@ -1,0 +1,611 @@
+﻿using Lumina.Data.Attributes;
+using Lumina.Data.Parsing.Scd;
+using Lumina.Extensions;
+using System;
+using System.Collections.Generic;
+
+namespace Lumina.Data.Files
+{
+    [FileExtension( ".scd" )]
+    public class ScdFile : FileResource
+    {
+        public class Sound
+        {
+            public ScdSound.SoundBasicDesc SoundBasicDesc;
+            public ScdSound.RoutingInfo? RoutingInfo;
+            public ScdSound.SendInfo[]? SendInfos;
+            public ScdSound.SoundEffectParam? SoundEffectParam;
+            public ScdSound.BusDuckingInfo? BusDuckingInfo;
+            public ScdSound.AccelerationInfo? AccelerationInfo;
+            public ScdSound.AtomosgearInfo? AtomosgearInfo;
+            public ScdSound.SoundExtraDesc? SoundExtraDesc;
+
+            public object TrackInfos;
+            public ScdSound.CycleInfo? CycleInfo;
+        }
+
+        public class Audio
+        {
+            public ScdAudio.AudioBasicDesc AudioBasicDesc;
+
+            public ScdAudio.SubInfoMarkerChunk? MarkerChunkHeader;
+            public uint[]? Markers;
+
+            public object? AudioDataHeader;
+            public uint[]? SeekTable;
+            public byte[] AudioData;
+        }
+
+        // stolen from FFXIV Explorer
+        private static readonly byte[] OggXorTable =
+        {
+            0x3A, 0x32, 0x32, 0x32, 0x03, 0x7E, 0x12, 0xF7, 0xB2, 0xE2, 0xA2, 0x67, 0x32, 0x32, 0x22, 0x32,
+            0x32, 0x52, 0x16, 0x1B, 0x3C, 0xA1, 0x54, 0x7B, 0x1B, 0x97, 0xA6, 0x93, 0x1A, 0x4B, 0xAA, 0xA6,
+            0x7A, 0x7B, 0x1B, 0x97, 0xA6, 0xF7, 0x02, 0xBB, 0xAA, 0xA6, 0xBB, 0xF7, 0x2A, 0x51, 0xBE, 0x03,
+            0xF4, 0x2A, 0x51, 0xBE, 0x03, 0xF4, 0x2A, 0x51, 0xBE, 0x12, 0x06, 0x56, 0x27, 0x32, 0x32, 0x36,
+            0x32, 0xB2, 0x1A, 0x3B, 0xBC, 0x91, 0xD4, 0x7B, 0x58, 0xFC, 0x0B, 0x55, 0x2A, 0x15, 0xBC, 0x40,
+            0x92, 0x0B, 0x5B, 0x7C, 0x0A, 0x95, 0x12, 0x35, 0xB8, 0x63, 0xD2, 0x0B, 0x3B, 0xF0, 0xC7, 0x14,
+            0x51, 0x5C, 0x94, 0x86, 0x94, 0x59, 0x5C, 0xFC, 0x1B, 0x17, 0x3A, 0x3F, 0x6B, 0x37, 0x32, 0x32,
+            0x30, 0x32, 0x72, 0x7A, 0x13, 0xB7, 0x26, 0x60, 0x7A, 0x13, 0xB7, 0x26, 0x50, 0xBA, 0x13, 0xB4,
+            0x2A, 0x50, 0xBA, 0x13, 0xB5, 0x2E, 0x40, 0xFA, 0x13, 0x95, 0xAE, 0x40, 0x38, 0x18, 0x9A, 0x92,
+            0xB0, 0x38, 0x00, 0xFA, 0x12, 0xB1, 0x7E, 0x00, 0xDB, 0x96, 0xA1, 0x7C, 0x08, 0xDB, 0x9A, 0x91,
+            0xBC, 0x08, 0xD8, 0x1A, 0x86, 0xE2, 0x70, 0x39, 0x1F, 0x86, 0xE0, 0x78, 0x7E, 0x03, 0xE7, 0x64,
+            0x51, 0x9C, 0x8F, 0x34, 0x6F, 0x4E, 0x41, 0xFC, 0x0B, 0xD5, 0xAE, 0x41, 0xFC, 0x0B, 0xD5, 0xAE,
+            0x41, 0xFC, 0x3B, 0x70, 0x71, 0x64, 0x33, 0x32, 0x12, 0x32, 0x32, 0x36, 0x70, 0x34, 0x2B, 0x56,
+            0x22, 0x70, 0x3A, 0x13, 0xB7, 0x26, 0x60, 0xBA, 0x1B, 0x94, 0xAA, 0x40, 0x38, 0x00, 0xFA, 0xB2,
+            0xE2, 0xA2, 0x67, 0x32, 0x32, 0x12, 0x32, 0xB2, 0x32, 0x32, 0x32, 0x32, 0x75, 0xA3, 0x26, 0x7B,
+            0x83, 0x26, 0xF9, 0x83, 0x2E, 0xFF, 0xE3, 0x16, 0x7D, 0xC0, 0x1E, 0x63, 0x21, 0x07, 0xE3, 0x01
+        };
+
+        private uint[] _soundOffsets = Array.Empty< uint >();
+        private uint[] _trackOffsets = Array.Empty< uint >();
+        private uint[] _audioOffsets = Array.Empty< uint >();
+        private uint _layoutOffset;
+        private uint _routingOffset; // unused in FFXIV?
+        private uint _attributeOffset;
+
+        public int SoundDataCount => _soundOffsets.Length;
+        public int TrackDataCount => _trackOffsets.Length;
+        public int AudioDataCount => _audioOffsets.Length;
+
+        public override void LoadFile()
+        {
+            var header = new ScdCommon.BinaryHeader( Reader );
+            var scdHeader = Reader.ReadStructure< ScdCommon.ScdHeader >();
+
+            _soundOffsets = new uint[ scdHeader.SoundCount ];
+            for( var i = 0; i < scdHeader.SoundCount; i++ )
+                _soundOffsets[ i ] = Reader.ReadUInt32();
+
+            Reader.BaseStream.Position = scdHeader.TrackOffset;
+            _trackOffsets = new uint[ scdHeader.TrackCount ];
+            for( var i = 0; i < scdHeader.TrackCount; i++ )
+                _trackOffsets[ i ] = Reader.ReadUInt32();
+
+            Reader.BaseStream.Position = scdHeader.AudioOffset;
+            _audioOffsets = new uint[ scdHeader.AudioCount ];
+            for( var i = 0; i < scdHeader.AudioCount; i++ )
+                _audioOffsets[ i ] = Reader.ReadUInt32();
+
+            if( scdHeader.LayoutOffset != 0 )
+            {
+                Reader.Position = scdHeader.LayoutOffset;
+                _layoutOffset = Reader.ReadUInt32();
+            }
+
+            if( scdHeader.RoutingOffset != 0 )
+            {
+                Reader.Position = scdHeader.RoutingOffset;
+                _routingOffset = Reader.ReadUInt32();
+            }
+
+            if( scdHeader.AttributeOffset != 0 )
+            {
+                Reader.Position = scdHeader.AttributeOffset;
+                _attributeOffset = Reader.ReadUInt32();
+            }
+        }
+
+        /// <summary>Parses the sound data at the given index.</summary>
+        /// <param name="index">The index into the stored sound offset array.</param>
+        /// <returns>A <c>Sound</c> object with all the information stored in the selected sound section.</returns>
+        public Sound GetSound( int index )
+        {
+            Reader.Position = _soundOffsets[ index ];
+            var soundBasicDesc = Reader.ReadStructure< ScdSound.SoundBasicDesc >();
+
+            var sound = new Sound();
+            sound.SoundBasicDesc = soundBasicDesc;
+
+            if( soundBasicDesc.Attribute.HasFlag( ScdSound.SoundAttribute.ExistRoutingSetting ) )
+            {
+                var routingInfo = Reader.ReadStructure< ScdSound.RoutingInfo >();
+                sound.RoutingInfo = routingInfo;
+                sound.SendInfos = Reader.ReadStructuresAsArray< ScdSound.SendInfo >( routingInfo.SendCount );
+                sound.SoundEffectParam = Reader.ReadStructure< ScdSound.SoundEffectParam >();
+            }
+
+            if( soundBasicDesc.Attribute.HasFlag( ScdSound.SoundAttribute.BusDucking ) )
+            {
+                sound.BusDuckingInfo = Reader.ReadStructure< ScdSound.BusDuckingInfo >();
+            }
+
+            if( soundBasicDesc.Attribute.HasFlag( ScdSound.SoundAttribute.Acceleration ) )
+            {
+                sound.AccelerationInfo = new ScdSound.AccelerationInfo( Reader );
+            }
+
+            if( soundBasicDesc.Attribute.HasFlag( ScdSound.SoundAttribute.Atomosgear ) )
+            {
+                sound.AtomosgearInfo = Reader.ReadStructure< ScdSound.AtomosgearInfo >();
+            }
+
+            if( soundBasicDesc.Attribute.HasFlag( ScdSound.SoundAttribute.ExtraDesc ) )
+            {
+                sound.SoundExtraDesc = Reader.ReadStructure< ScdSound.SoundExtraDesc >();
+            }
+
+            if( soundBasicDesc.Type is ScdSound.SoundType.Random or ScdSound.SoundType.Cycle or ScdSound.SoundType.GroupRandom )
+            {
+                sound.TrackInfos = Reader.ReadStructures< ScdSound.RandomTrackInfo >( soundBasicDesc.TrackCount );
+
+                if( soundBasicDesc.Type == ScdSound.SoundType.Cycle )
+                {
+                    sound.CycleInfo = Reader.ReadStructure< ScdSound.CycleInfo >();
+                }
+            }
+            else
+            {
+                sound.TrackInfos = Reader.ReadStructures< ScdSound.TrackInfo >( soundBasicDesc.TrackCount );
+            }
+
+            return sound;
+        }
+
+        // Just a prototype, don't use it.
+        public List< ( ScdTrack.TrackCmd cmd, object? data ) > GetTrack( int index )
+        {
+            Reader.Position = _trackOffsets[ index ];
+            var trackCmdData = new List< (ScdTrack.TrackCmd, object?) >();
+
+            while( true )
+            {
+                var cmd = (ScdTrack.TrackCmd)Reader.ReadUInt16();
+                object? data = null;
+
+                switch( cmd )
+                {
+                    case ScdTrack.TrackCmd.End:
+                        trackCmdData.Add( ( cmd, null ) );
+                        return trackCmdData;
+
+                    case ScdTrack.TrackCmd.Volume:
+                        data = Reader.ReadStructure< ScdTrack.TrackCmdParam >();
+                        break;
+
+                    case ScdTrack.TrackCmd.Pitch:
+                        data = Reader.ReadStructure< ScdTrack.TrackCmdParam >();
+                        break;
+
+                    case ScdTrack.TrackCmd.Interval:
+                        data = Reader.ReadUInt32();
+                        break;
+
+                    case ScdTrack.TrackCmd.Modulation:
+                        data = Reader.ReadStructure< ScdTrack.ModulationCmdParam >();
+                        break;
+
+                    case ScdTrack.TrackCmd.ReleaseRate:
+                        data = Reader.ReadUInt32();
+                        break;
+
+                    case ScdTrack.TrackCmd.Panning:
+                        data = Reader.ReadStructure< ScdTrack.TrackCmdParam >();
+                        break;
+
+                    case ScdTrack.TrackCmd.KeyOn:
+                        break;
+
+                    case ScdTrack.TrackCmd.RandomVolume:
+                        data = Reader.ReadStructure< ScdTrack.RandomCmdParam >();
+                        break;
+
+                    case ScdTrack.TrackCmd.RandomPitch:
+                        data = Reader.ReadStructure< ScdTrack.RandomCmdParam >();
+                        break;
+
+                    case ScdTrack.TrackCmd.RandomPan:
+                        data = Reader.ReadStructure< ScdTrack.RandomCmdParam >();
+                        break;
+
+                    case ScdTrack.TrackCmd.KeyOff:
+                        break;
+
+                    case ScdTrack.TrackCmd.LoopStart:
+                        data = Reader.ReadUInt32Array( 2 ); // loopLowerCnt, loopUpperCnt
+                        break;
+
+                    case ScdTrack.TrackCmd.LoopEnd:
+                        break;
+
+                    case ScdTrack.TrackCmd.ExternalAudio:
+                        data = new ScdTrack.ExternalAudioInfo( Reader );
+                        break;
+
+                    case ScdTrack.TrackCmd.EndForLoop:
+                        trackCmdData.Add( ( cmd, null ) );
+                        return trackCmdData;
+
+                    case ScdTrack.TrackCmd.AddInterval:
+                        data = Reader.ReadSingle();
+                        break;
+
+                    case ScdTrack.TrackCmd.Expression:
+                        data = Reader.ReadSingleArray( 2 ); // lowerExpression, upperExpression
+                        break;
+
+                    case ScdTrack.TrackCmd.Velocity:
+                        data = Reader.ReadSingle();
+                        break;
+
+                    case ScdTrack.TrackCmd.MidiVolume:
+                        data = Reader.ReadSingleArray( 2 ); // lowerVolume, upperVolume
+                        break;
+
+                    case ScdTrack.TrackCmd.MidiAddVolume:
+                        data = Reader.ReadSingle();
+                        break;
+
+                    case ScdTrack.TrackCmd.MidiPan:
+                        data = Reader.ReadSingleArray( 2 ); // lowerPan, upperPan
+                        break;
+
+                    case ScdTrack.TrackCmd.MidiAddPan:
+                        data = Reader.ReadSingle();
+                        break;
+
+                    case ScdTrack.TrackCmd.ModulationType:
+                        data = ( (ScdTrack.OscillatorCarrier)Reader.ReadUInt32(), (ScdTrack.OscillatorMode)Reader.ReadUInt32() );
+                        break;
+
+                    case ScdTrack.TrackCmd.ModulationDepth:
+                        data = new ScdTrack.ModulationDepth
+                        {
+                            Carrier = Reader.ReadUInt32(),
+                            Depth = Reader.ReadSingle()
+                        };
+                        break;
+
+                    case ScdTrack.TrackCmd.ModulationAddDepth:
+                        data = new ScdTrack.ModulationDepth
+                        {
+                            Carrier = Reader.ReadUInt32(),
+                            Depth = Reader.ReadSingle()
+                        };
+                        break;
+
+                    case ScdTrack.TrackCmd.ModulationSpeed:
+                        data = new ScdTrack.ModulationSpeed
+                        {
+                            Carrier = Reader.ReadUInt32(),
+                            Speed = Reader.ReadUInt32()
+                        };
+                        break;
+
+                    case ScdTrack.TrackCmd.ModulationAddSpeed:
+                        data = new ScdTrack.ModulationSpeed
+                        {
+                            Carrier = Reader.ReadUInt32(),
+                            Speed = Reader.ReadUInt32()
+                        };
+                        break;
+
+                    case ScdTrack.TrackCmd.ModulationOff:
+                        data = (ScdTrack.OscillatorCarrier)Reader.ReadUInt32();
+                        break;
+
+                    case ScdTrack.TrackCmd.PitchBend:
+                        data = Reader.ReadSingleArray( 2 ); // lowerPitch, upperPitch
+                        break;
+
+                    case ScdTrack.TrackCmd.Transpose:
+                        data = Reader.ReadSingleArray( 2 ); // lowerPitch, upperPitch
+                        break;
+
+                    case ScdTrack.TrackCmd.AddTranspose:
+                        data = Reader.ReadSingle();
+                        break;
+
+                    case ScdTrack.TrackCmd.FrPanning:
+                        data = Reader.ReadStructure< ScdTrack.TrackCmdParam >();
+                        break;
+
+                    case ScdTrack.TrackCmd.RandomWait:
+                        data = Reader.ReadUInt32Array( 2 ); // lowerWait, upperWait
+                        break;
+
+                    case ScdTrack.TrackCmd.Adsr:
+                        data = Reader.ReadStructure< ScdTrack.TrackCmdParam >();
+                        break;
+
+                    case ScdTrack.TrackCmd.CutOff:
+                        break;
+
+                    case ScdTrack.TrackCmd.Jump:
+                        data = ( (ScdTrack.TrackCmdJump)Reader.ReadUInt32(), Reader.ReadInt32() ); // condition, offset
+                        break;
+
+                    case ScdTrack.TrackCmd.PlayContinueLoop:
+                        break;
+
+                    case ScdTrack.TrackCmd.Sweep:
+                        data = ( Reader.ReadSingle(), Reader.ReadUInt32() ); // pitch, time
+                        break;
+
+                    case ScdTrack.TrackCmd.MidiKeyOnOld:
+                        break;
+
+                    case ScdTrack.TrackCmd.SlurOn:
+                        break;
+
+                    case ScdTrack.TrackCmd.SlurOff:
+                        break;
+
+                    case ScdTrack.TrackCmd.AutoAdsrEnvelope:
+                        data = Reader.ReadStructure< ScdTrack.AutoAdsrEnvelope >();
+                        break;
+
+                    case ScdTrack.TrackCmd.MidiExternalAudio:
+                        data = new ScdTrack.ExternalAudioInfo( Reader );
+                        break;
+
+                    case ScdTrack.TrackCmd.Marker:
+                        break;
+
+                    case ScdTrack.TrackCmd.InitParams:
+                        break;
+
+                    case ScdTrack.TrackCmd.Version:
+                        data = Reader.ReadUInt16();
+                        break;
+
+                    case ScdTrack.TrackCmd.ReverbOn:
+                        data = Reader.ReadSingle(); // reverbDryVolume
+                        break;
+
+                    case ScdTrack.TrackCmd.ReverbOff:
+                        break;
+
+                    case ScdTrack.TrackCmd.MidiKeyOn:
+                        data = Reader.ReadSingleArray( 2 ); // velocity, pitch
+                        break;
+
+                    case ScdTrack.TrackCmd.PortamentoOn:
+                        data = ( Reader.ReadInt32(), Reader.ReadSingle() ); // portamentoTime, pitch
+                        break;
+
+                    case ScdTrack.TrackCmd.PortamentoOff:
+                        break;
+
+                    case ScdTrack.TrackCmd.MidiEnd:
+                        trackCmdData.Add( ( cmd, null ) );
+                        return trackCmdData;
+
+                    case ScdTrack.TrackCmd.ClearKeyInfo:
+                        break;
+
+                    case ScdTrack.TrackCmd.ModulationDepthFade:
+                        data = new ScdTrack.ModulationDepth
+                        {
+                            Carrier = Reader.ReadUInt32(),
+                            Depth = Reader.ReadSingle(),
+                            FadeTime = Reader.ReadInt32()
+                        };
+                        break;
+
+                    case ScdTrack.TrackCmd.ModulationSpeedFade:
+                        data = new ScdTrack.ModulationSpeed
+                        {
+                            Carrier = Reader.ReadUInt32(),
+                            Speed = Reader.ReadUInt32(),
+                            FadeTime = Reader.ReadInt32()
+                        };
+                        break;
+
+                    case ScdTrack.TrackCmd.AnalysisFlag:
+                        data = Reader.ReadUInt16Array( Reader.ReadUInt16() );
+                        break;
+
+                    case ScdTrack.TrackCmd.Config:
+                        var trackConfig = new ScdTrack.TrackConfig
+                        {
+                            Type = (ScdTrack.TrackCmdConfigType)Reader.ReadUInt16(),
+                            Count = Reader.ReadUInt16()
+                        };
+
+                        if( trackConfig.Type == ScdTrack.TrackCmdConfigType.IntervalTypeFloat )
+                        {
+                            trackConfig.Data = Reader.ReadUInt16() != 0;
+                        }
+                        else if( trackConfig.Type > ScdTrack.TrackCmdConfigType.IntervalTypeFloat )
+                        {
+                            trackConfig.Data = Reader.ReadUInt16Array( trackConfig.Count );
+                        }
+
+                        data = trackConfig;
+                        break;
+
+                    case ScdTrack.TrackCmd.Filter:
+                        data = Reader.ReadStructure< ScdTrack.TrackFilter >();
+                        break;
+
+                    case ScdTrack.TrackCmd.PlayInnerSound:
+                        data = Reader.ReadUInt16Array( 2 ); // bankNumber, soundIndex
+                        break;
+
+                    case ScdTrack.TrackCmd.VolumeZeroOne:
+                        var zeroOneHeader = Reader.ReadStructure< ScdTrack.TrackZeroOneParamHeader >();
+                        data = Reader.ReadStructuresAsArray< ScdTrack.TrackZeroOnePoint >( zeroOneHeader.NumPoints );
+                        break;
+
+                    case ScdTrack.TrackCmd.ZeroOneJump:
+                        data = Reader.ReadInt32(); // jumpTarget
+                        break;
+
+                    case ScdTrack.TrackCmd.ChannelVolumeZeroOne:
+                        var channelZeroOneHeader = Reader.ReadStructure< ScdTrack.TrackChannelZeroOneParamHeader >();
+                        var zeroOnePoints = new ScdTrack.TrackZeroOnePoint[ channelZeroOneHeader.NumChannels ][];
+
+                        for( var i = 0; i < channelZeroOneHeader.NumChannels; i++ )
+                        {
+                            var zeroOneParamHeader = Reader.ReadStructure< ScdTrack.TrackZeroOneParamHeader >();
+                            zeroOnePoints[ i ] = Reader.ReadStructuresAsArray< ScdTrack.TrackZeroOnePoint >( zeroOneParamHeader.NumPoints );
+                        }
+
+                        data = zeroOnePoints;
+                        break;
+
+                    case ScdTrack.TrackCmd.Unknown64:
+                        var unknownHeader = Reader.ReadStructure< ScdTrack.TrackUnknown64Header >();
+                        data = Reader.ReadStructures< ScdTrack.TrackUnknown64 >( unknownHeader.Count );
+                        break;
+
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+
+                trackCmdData.Add( ( cmd, data ) );
+            }
+        }
+
+        /// <summary>Parses the audio data at the given index.</summary>
+        /// <param name="index">The index into the stored audio offset array.</param>
+        /// <returns>
+        /// An <c>Audio</c> object with all the information stored in
+        /// the selected audio section, including the audio stream.
+        /// </returns>
+        public Audio GetAudio( int index )
+        {
+            Reader.Position = _audioOffsets[ index ];
+            var audioBasicDesc = Reader.ReadStructure< ScdAudio.AudioBasicDesc >();
+
+            var audio = new Audio();
+            audio.AudioBasicDesc = audioBasicDesc;
+
+            var subInfoStartPos = Reader.Position;
+            if( audioBasicDesc.Flg.HasFlag( ScdAudio.AudioFlag.MarkerChunk ) )
+            {
+                var subInfoMarkerChunk = Reader.ReadStructure< ScdAudio.SubInfoMarkerChunk >();
+                audio.MarkerChunkHeader = subInfoMarkerChunk;
+                audio.Markers = Reader.ReadUInt32Array( subInfoMarkerChunk.NumMarkers );
+
+                Reader.Position = subInfoStartPos + subInfoMarkerChunk.Header.Size;
+            }
+
+            switch( audioBasicDesc.Format )
+            {
+                case ScdAudio.AudioFormat.Empty:
+                    audio.AudioData = Array.Empty< byte >();
+                    break;
+
+                case ScdAudio.AudioFormat.OggVorbis:
+                {
+                    var oggSeekTableHeader = Reader.ReadStructure< ScdAudio.OggVorbisSeekTableHeader >();
+                    audio.AudioDataHeader = oggSeekTableHeader;
+                    audio.SeekTable = Reader.ReadUInt32Array( (int)( oggSeekTableHeader.SeekTableSize / 4 ) );
+
+                    Reader.Position = subInfoStartPos + audioBasicDesc.SubInfoSize;
+
+                    var oggFile = new byte[ oggSeekTableHeader.OggHeaderSize + audioBasicDesc.Size ];
+                    Array.Copy( Reader.ReadBytes( (int)oggSeekTableHeader.OggHeaderSize ), oggFile, oggSeekTableHeader.OggHeaderSize );
+                    Array.Copy( Reader.ReadBytes( (int)audioBasicDesc.Size ), 0, oggFile, oggSeekTableHeader.OggHeaderSize, audioBasicDesc.Size );
+
+                    switch( oggSeekTableHeader.Version )
+                    {
+                        case 2:
+                            for( var j = 0; j < oggSeekTableHeader.OggHeaderSize; j++ )
+                                oggFile[ j ] ^= oggSeekTableHeader.XorByte;
+                            break;
+
+                        case 3:
+                            var byte1 = (byte)( audioBasicDesc.Size & 0x7F );
+                            var byte2 = (byte)( byte1 & 0x3F );
+
+                            for( var j = 0; j < oggFile.Length; j++ )
+                            {
+                                byte xorByte = OggXorTable[ ( byte2 + j ) & 0xFF ];
+                                xorByte ^= oggFile[ j ];
+                                xorByte ^= byte1;
+                                oggFile[ j ] = xorByte;
+                            }
+
+                            break;
+                    }
+
+                    audio.AudioData = oggFile;
+                    break;
+                }
+
+                case ScdAudio.AudioFormat.Mp3:
+                    var id = Reader.PeekBytes( 4 );
+                    if( id[ 0 ] == 'S' && id[ 1 ] == 'T' && id[ 2 ] == 'B' && id[ 3 ] == 'L' )
+                    {
+                        var mp3SeekTableHeader = Reader.ReadStructure< ScdAudio.PS3MP3SeekTableHeader >();
+                        audio.AudioDataHeader = mp3SeekTableHeader;
+                        audio.SeekTable = Reader.ReadUInt32Array( mp3SeekTableHeader.NumElement );
+                    }
+                    else
+                    {
+                        // step size is 1 second
+                        audio.SeekTable = Reader.ReadUInt32Array( Reader.ReadInt32() );
+                    }
+
+                    Reader.Position = subInfoStartPos + audioBasicDesc.SubInfoSize;
+                    audio.AudioData = Reader.ReadBytes( (int)audioBasicDesc.Size );
+                    break;
+
+                case ScdAudio.AudioFormat.MsAdpcm:
+                    audio.AudioDataHeader = Reader.ReadStructure< ScdAudio.AdpcmWaveFormat >();
+                    Reader.Position = subInfoStartPos + audioBasicDesc.SubInfoSize;
+                    audio.AudioData = Reader.ReadBytes( (int)audioBasicDesc.Size );
+                    break;
+
+                case ScdAudio.AudioFormat.Atrac9:
+                    audio.AudioDataHeader = Reader.ReadStructure< ScdAudio.ATRAC9Header >();
+                    Reader.Position = subInfoStartPos + audioBasicDesc.SubInfoSize;
+                    audio.AudioData = Reader.ReadBytes( (int)audioBasicDesc.Size );
+                    break;
+
+                case (ScdAudio.AudioFormat)5: // headerless Atrac3 stream?
+                default:
+                    System.Diagnostics.Debug.WriteLine( "Unknown audio format type id " + audioBasicDesc.Format );
+
+                    Reader.Position = subInfoStartPos + audioBasicDesc.SubInfoSize;
+                    audio.AudioData = Reader.ReadBytes( (int)audioBasicDesc.Size );
+                    break;
+            }
+
+            return audio;
+        }
+
+        /// <summary>Parses the layout data.</summary>
+        public ScdLayout.SoundObject? GetLayout()
+        {
+            if( _layoutOffset == 0 )
+                return null;
+
+            Reader.BaseStream.Position = _layoutOffset;
+            return new ScdLayout.SoundObject( Reader );
+        }
+
+        /// <summary>Parses the attribute data.</summary>
+        public ScdAttribute.AttributeData? GetAttributeData()
+        {
+            if( _attributeOffset == 0 )
+                return null;
+
+            Reader.Position = _attributeOffset;
+            return new ScdAttribute.AttributeData( Reader );
+        }
+    }
+}

--- a/src/Lumina/Data/Parsing/Scd/ScdAttribute.cs
+++ b/src/Lumina/Data/Parsing/Scd/ScdAttribute.cs
@@ -1,0 +1,132 @@
+using System;
+
+#pragma warning disable CS1591
+
+namespace Lumina.Data.Parsing.Scd
+{
+    public static class ScdAttribute
+    {
+        public struct AttributeData
+        {
+            [Flags]
+            public enum ConditionType1st : byte
+            {
+                Attr = 0x01,
+                Label = 0x02,
+                Equal = 0x04,
+                Bank = 0x08,
+                ExternalId1st = 0x10
+            }
+
+            public enum ConditionType2nd : byte
+            {
+                None = 0x00,
+                Frame = 0x01,
+                Volume = 0x02,
+                Pan = 0x03,
+                Count = 0x04,
+                Priority = 0x05,
+                ExternalId = 0x06,
+                TypeMask = 0x0F,
+                GE = 0x00,
+                GT = 0x10,
+                LT = 0x20,
+                LE = 0x30,
+                EQ = 0x40,
+                NE = 0x50,
+                CondMask = 0xF0
+            }
+
+            public enum JoinType : byte
+            {
+                And,
+                Or
+            }
+
+            public enum SelfCommand : byte
+            {
+                None,
+                FadeIn,
+                ChgPriority,
+                FreezePan,
+                Stay,
+                ChgPan,
+                BanRear,
+                NoPlay,
+                ChgDepth,
+                MonoSpeaker,
+                ChgVolume,
+                ChgBusNo,
+                ChgBusVolume
+            }
+
+            public enum TargetCommand : byte
+            {
+                None,
+                Stop,
+                ChgPriority,
+                FadeOut,
+                ChgPitch,
+                PriorityStop,
+                ChgPan,
+                ChgVolume,
+                OldStop,
+                BanRear,
+                ChgDepth,
+                ChgBusNo,
+                LowExternalIdOldStop,
+                MinVolumeStop
+            }
+
+            public unsafe struct ResultCommand
+            {
+                public SelfCommand Self;
+                public TargetCommand Target;
+                private fixed byte _padding3[2];
+                public uint SelfArgument;
+                public uint TargetArgument;
+            }
+
+            public struct ExtendCondition
+            {
+                public ConditionType1st Condition1;
+                public ConditionType2nd Condition2;
+                public JoinType Join;
+                public byte NumOfCond;
+                public uint SelfArgument;
+                public uint TargetArgument;
+            }
+
+            public struct ExtendData
+            {
+                public ExtendCondition Condition;
+                public ResultCommand Result;
+            }
+
+            public byte Version;
+            private byte _padding1;
+            public ushort AttributeId;
+            public ushort SearchAttributeId;
+            public byte Condition1st;
+            public byte ArgCount;
+            public uint SoundLabelLo;
+            public uint SoundLabelHi;
+            public ResultCommand Result1st;
+            public ExtendData[] Extend;
+
+            public AttributeData( LuminaBinaryReader binaryReader )
+            {
+                Version = binaryReader.ReadByte();
+                _padding1 = binaryReader.ReadByte();
+                AttributeId = binaryReader.ReadUInt16();
+                SearchAttributeId = binaryReader.ReadUInt16();
+                Condition1st = binaryReader.ReadByte();
+                ArgCount = binaryReader.ReadByte();
+                SoundLabelLo = binaryReader.ReadUInt32();
+                SoundLabelHi = binaryReader.ReadUInt32();
+                Result1st = binaryReader.ReadStructure< ResultCommand >();
+                Extend = binaryReader.ReadStructuresAsArray< ExtendData >( 4 );
+            }
+        }
+    }
+}

--- a/src/Lumina/Data/Parsing/Scd/ScdAttribute.cs
+++ b/src/Lumina/Data/Parsing/Scd/ScdAttribute.cs
@@ -4,129 +4,126 @@ using System;
 
 namespace Lumina.Data.Parsing.Scd
 {
-    public static class ScdAttribute
+    public struct AttributeData
     {
-        public struct AttributeData
+        [Flags]
+        public enum ConditionType1st : byte
         {
-            [Flags]
-            public enum ConditionType1st : byte
-            {
-                Attr = 0x01,
-                Label = 0x02,
-                Equal = 0x04,
-                Bank = 0x08,
-                ExternalId1st = 0x10
-            }
+            Attr = 0x01,
+            Label = 0x02,
+            Equal = 0x04,
+            Bank = 0x08,
+            ExternalId1st = 0x10
+        }
 
-            public enum ConditionType2nd : byte
-            {
-                None = 0x00,
-                Frame = 0x01,
-                Volume = 0x02,
-                Pan = 0x03,
-                Count = 0x04,
-                Priority = 0x05,
-                ExternalId = 0x06,
-                TypeMask = 0x0F,
-                GE = 0x00,
-                GT = 0x10,
-                LT = 0x20,
-                LE = 0x30,
-                EQ = 0x40,
-                NE = 0x50,
-                CondMask = 0xF0
-            }
+        public enum ConditionType2nd : byte
+        {
+            None = 0x00,
+            Frame = 0x01,
+            Volume = 0x02,
+            Pan = 0x03,
+            Count = 0x04,
+            Priority = 0x05,
+            ExternalId = 0x06,
+            TypeMask = 0x0F,
+            GE = 0x00,
+            GT = 0x10,
+            LT = 0x20,
+            LE = 0x30,
+            EQ = 0x40,
+            NE = 0x50,
+            CondMask = 0xF0
+        }
 
-            public enum JoinType : byte
-            {
-                And,
-                Or
-            }
+        public enum JoinType : byte
+        {
+            And,
+            Or
+        }
 
-            public enum SelfCommand : byte
-            {
-                None,
-                FadeIn,
-                ChgPriority,
-                FreezePan,
-                Stay,
-                ChgPan,
-                BanRear,
-                NoPlay,
-                ChgDepth,
-                MonoSpeaker,
-                ChgVolume,
-                ChgBusNo,
-                ChgBusVolume
-            }
+        public enum SelfCommand : byte
+        {
+            None,
+            FadeIn,
+            ChgPriority,
+            FreezePan,
+            Stay,
+            ChgPan,
+            BanRear,
+            NoPlay,
+            ChgDepth,
+            MonoSpeaker,
+            ChgVolume,
+            ChgBusNo,
+            ChgBusVolume
+        }
 
-            public enum TargetCommand : byte
-            {
-                None,
-                Stop,
-                ChgPriority,
-                FadeOut,
-                ChgPitch,
-                PriorityStop,
-                ChgPan,
-                ChgVolume,
-                OldStop,
-                BanRear,
-                ChgDepth,
-                ChgBusNo,
-                LowExternalIdOldStop,
-                MinVolumeStop
-            }
+        public enum TargetCommand : byte
+        {
+            None,
+            Stop,
+            ChgPriority,
+            FadeOut,
+            ChgPitch,
+            PriorityStop,
+            ChgPan,
+            ChgVolume,
+            OldStop,
+            BanRear,
+            ChgDepth,
+            ChgBusNo,
+            LowExternalIdOldStop,
+            MinVolumeStop
+        }
 
-            public unsafe struct ResultCommand
-            {
-                public SelfCommand Self;
-                public TargetCommand Target;
-                private fixed byte _padding3[2];
-                public uint SelfArgument;
-                public uint TargetArgument;
-            }
+        public unsafe struct ResultCommand
+        {
+            public SelfCommand Self;
+            public TargetCommand Target;
+            private fixed byte _padding3[2];
+            public uint SelfArgument;
+            public uint TargetArgument;
+        }
 
-            public struct ExtendCondition
-            {
-                public ConditionType1st Condition1;
-                public ConditionType2nd Condition2;
-                public JoinType Join;
-                public byte NumOfCond;
-                public uint SelfArgument;
-                public uint TargetArgument;
-            }
+        public struct ExtendCondition
+        {
+            public ConditionType1st Condition1;
+            public ConditionType2nd Condition2;
+            public JoinType Join;
+            public byte NumOfCond;
+            public uint SelfArgument;
+            public uint TargetArgument;
+        }
 
-            public struct ExtendData
-            {
-                public ExtendCondition Condition;
-                public ResultCommand Result;
-            }
+        public struct ExtendData
+        {
+            public ExtendCondition Condition;
+            public ResultCommand Result;
+        }
 
-            public byte Version;
-            private byte _padding1;
-            public ushort AttributeId;
-            public ushort SearchAttributeId;
-            public byte Condition1st;
-            public byte ArgCount;
-            public uint SoundLabelLo;
-            public uint SoundLabelHi;
-            public ResultCommand Result1st;
-            public ExtendData[] Extend;
+        public byte Version;
+        private byte _padding1;
+        public ushort AttributeId;
+        public ushort SearchAttributeId;
+        public byte Condition1st;
+        public byte ArgCount;
+        public uint SoundLabelLo;
+        public uint SoundLabelHi;
+        public ResultCommand Result1st;
+        public ExtendData[] Extend;
 
-            public AttributeData( LuminaBinaryReader binaryReader )
-            {
-                Version = binaryReader.ReadByte();
-                _padding1 = binaryReader.ReadByte();
-                AttributeId = binaryReader.ReadUInt16();
-                SearchAttributeId = binaryReader.ReadUInt16();
-                Condition1st = binaryReader.ReadByte();
-                ArgCount = binaryReader.ReadByte();
-                SoundLabelLo = binaryReader.ReadUInt32();
-                SoundLabelHi = binaryReader.ReadUInt32();
-                Result1st = binaryReader.ReadStructure< ResultCommand >();
-                Extend = binaryReader.ReadStructuresAsArray< ExtendData >( 4 );
-            }
+        public AttributeData( LuminaBinaryReader binaryReader )
+        {
+            Version = binaryReader.ReadByte();
+            _padding1 = binaryReader.ReadByte();
+            AttributeId = binaryReader.ReadUInt16();
+            SearchAttributeId = binaryReader.ReadUInt16();
+            Condition1st = binaryReader.ReadByte();
+            ArgCount = binaryReader.ReadByte();
+            SoundLabelLo = binaryReader.ReadUInt32();
+            SoundLabelHi = binaryReader.ReadUInt32();
+            Result1st = binaryReader.ReadStructure< ResultCommand >();
+            Extend = binaryReader.ReadStructuresAsArray< ExtendData >( 4 );
         }
     }
 }

--- a/src/Lumina/Data/Parsing/Scd/ScdAudio.cs
+++ b/src/Lumina/Data/Parsing/Scd/ScdAudio.cs
@@ -1,0 +1,105 @@
+using System;
+
+#pragma warning disable CS1591
+
+namespace Lumina.Data.Parsing.Scd
+{
+    public static class ScdAudio
+    {
+        [Flags]
+        public enum AudioFlag
+        {
+            MarkerChunk = 0x01,
+            MonoSplit = 0x02,
+            VersionShiftBit = 0x01000000
+        }
+
+        public enum AudioFormat
+        {
+            Empty = -1,
+            OggVorbis = 6,  // PC music
+            Mp3 = 7,        // PS3
+            MsAdpcm = 12,   // PC sound
+            Atrac9 = 22     // PS4
+        }
+
+        public struct AudioBasicDesc
+        {
+            public uint Size;
+            public uint Channel;
+            public uint Rate;
+            public AudioFormat Format;
+            public uint LoopStart;
+            public uint LoopEnd;
+            public uint SubInfoSize;
+            public AudioFlag Flg;
+        }
+
+        public struct SubInfoChunkHeader
+        {
+            public uint Id;
+            public uint Size;
+        }
+
+        public struct SubInfoMarkerChunk
+        {
+            public SubInfoChunkHeader Header;
+            public int SampleLoopStartPos;
+            public int SampleLoopEndPos;
+            public int NumMarkers;
+        }
+
+        public unsafe struct OggVorbisSeekTableHeader
+        {
+            public byte Version;
+            public byte StructSize;
+            public byte XorByte;
+            public fixed byte Unknown[9];
+            public float Step;
+            public uint SeekTableSize;
+            public uint OggHeaderSize;
+            private fixed uint _padding[2];
+        }
+
+        public unsafe struct PS3MP3SeekTableHeader
+        {
+            public fixed byte Id[4];
+            public byte Version;
+            public fixed byte reserved[3];
+            public float Step;
+            public int NumElement;
+        }
+
+        public unsafe struct AdpcmWaveFormat
+        {
+            public ushort FormatTag;
+            public short Channels;
+            public int SamplesPerSec;
+            public int AvgBytesPerSec;
+            public short BlockAlign;
+            public ushort BitsPerSample;
+            public short Size;
+            public ushort SamplesPerBlock;
+            public ushort NumCoef;
+            public fixed short Coef[14];
+        }
+
+        // structured with information from vgmstream
+        public unsafe struct ATRAC9Header
+        {
+            public ushort Version;
+            public ushort StructSize;
+            public ushort SuperframeBytes;
+            public ushort SuperframeSamples;
+            public uint Unknown;
+            public uint ConfigData;
+            public uint SampleCount;
+            public uint Unknown0;
+            public uint SampleDelay;
+            public uint SampleRate;
+            public uint SampleLoopStart;
+            public uint SampleLoopEnd;
+            private fixed uint _padding[2];
+        }
+    }
+}

--- a/src/Lumina/Data/Parsing/Scd/ScdAudio.cs
+++ b/src/Lumina/Data/Parsing/Scd/ScdAudio.cs
@@ -4,102 +4,99 @@ using System;
 
 namespace Lumina.Data.Parsing.Scd
 {
-    public static class ScdAudio
+    [Flags]
+    public enum AudioFlag
     {
-        [Flags]
-        public enum AudioFlag
-        {
-            MarkerChunk = 0x01,
-            MonoSplit = 0x02,
-            VersionShiftBit = 0x01000000
-        }
+        MarkerChunk = 0x01,
+        MonoSplit = 0x02,
+        VersionShiftBit = 0x01000000
+    }
 
-        public enum AudioFormat
-        {
-            Empty = -1,
-            OggVorbis = 6,  // PC music
-            Mp3 = 7,        // PS3
-            MsAdpcm = 12,   // PC sound
-            Atrac9 = 22     // PS4
-        }
+    public enum AudioFormat
+    {
+        Empty = -1,
+        OggVorbis = 6,  // PC music
+        Mp3 = 7,        // PS3
+        MsAdpcm = 12,   // PC sound
+        Atrac9 = 22     // PS4
+    }
 
-        public struct AudioBasicDesc
-        {
-            public uint Size;
-            public uint Channel;
-            public uint Rate;
-            public AudioFormat Format;
-            public uint LoopStart;
-            public uint LoopEnd;
-            public uint SubInfoSize;
-            public AudioFlag Flg;
-        }
+    public struct AudioBasicDesc
+    {
+        public uint Size;
+        public uint Channel;
+        public uint Rate;
+        public AudioFormat Format;
+        public uint LoopStart;
+        public uint LoopEnd;
+        public uint SubInfoSize;
+        public AudioFlag Flg;
+    }
 
-        public struct SubInfoChunkHeader
-        {
-            public uint Id;
-            public uint Size;
-        }
+    public struct SubInfoChunkHeader
+    {
+        public uint Id;
+        public uint Size;
+    }
 
-        public struct SubInfoMarkerChunk
-        {
-            public SubInfoChunkHeader Header;
-            public int SampleLoopStartPos;
-            public int SampleLoopEndPos;
-            public int NumMarkers;
-        }
+    public struct SubInfoMarkerChunk
+    {
+        public SubInfoChunkHeader Header;
+        public int SampleLoopStartPos;
+        public int SampleLoopEndPos;
+        public int NumMarkers;
+    }
 
-        public unsafe struct OggVorbisSeekTableHeader
-        {
-            public byte Version;
-            public byte StructSize;
-            public byte XorByte;
-            public fixed byte Unknown[9];
-            public float Step;
-            public uint SeekTableSize;
-            public uint OggHeaderSize;
-            private fixed uint _padding[2];
-        }
+    public unsafe struct OggVorbisSeekTableHeader
+    {
+        public byte Version;
+        public byte StructSize;
+        public byte XorByte;
+        public fixed byte Unknown[9];
+        public float Step;
+        public uint SeekTableSize;
+        public uint OggHeaderSize;
+        private fixed uint _padding[2];
+    }
 
-        public unsafe struct PS3MP3SeekTableHeader
-        {
-            public fixed byte Id[4];
-            public byte Version;
-            public fixed byte reserved[3];
-            public float Step;
-            public int NumElement;
-        }
+    public unsafe struct PS3MP3SeekTableHeader
+    {
+        public fixed byte Id[4];
+        public byte Version;
+        public fixed byte reserved[3];
+        public float Step;
+        public int NumElement;
+    }
 
-        public unsafe struct AdpcmWaveFormat
-        {
-            public ushort FormatTag;
-            public short Channels;
-            public int SamplesPerSec;
-            public int AvgBytesPerSec;
-            public short BlockAlign;
-            public ushort BitsPerSample;
-            public short Size;
-            public ushort SamplesPerBlock;
-            public ushort NumCoef;
-            public fixed short Coef[14];
-        }
+    public unsafe struct AdpcmWaveFormat
+    {
+        public ushort FormatTag;
+        public short Channels;
+        public int SamplesPerSec;
+        public int AvgBytesPerSec;
+        public short BlockAlign;
+        public ushort BitsPerSample;
+        public short Size;
+        public ushort SamplesPerBlock;
+        public ushort NumCoef;
+        public fixed short Coef[14];
+    }
 
-        // structured with information from vgmstream
-        public unsafe struct ATRAC9Header
-        {
-            public ushort Version;
-            public ushort StructSize;
-            public ushort SuperframeBytes;
-            public ushort SuperframeSamples;
-            public uint Unknown;
-            public uint ConfigData;
-            public uint SampleCount;
-            public uint Unknown0;
-            public uint SampleDelay;
-            public uint SampleRate;
-            public uint SampleLoopStart;
-            public uint SampleLoopEnd;
-            private fixed uint _padding[2];
-        }
+    // structured with information from vgmstream
+    public unsafe struct ATRAC9Header
+    {
+        public ushort Version;
+        public ushort StructSize;
+        public ushort SuperframeBytes;
+        public ushort SuperframeSamples;
+        public uint Unknown;
+        public uint ConfigData;
+        public uint SampleCount;
+        public uint Unknown0;
+        public uint SampleDelay;
+        public uint SampleRate;
+        public uint SampleLoopStart;
+        public uint SampleLoopEnd;
+        private fixed uint _padding[2];
     }
 }

--- a/src/Lumina/Data/Parsing/Scd/ScdCommon.cs
+++ b/src/Lumina/Data/Parsing/Scd/ScdCommon.cs
@@ -5,60 +5,57 @@ using System.Buffers.Binary;
 
 namespace Lumina.Data.Parsing.Scd
 {
-    public static class ScdCommon
+    public struct BinaryHeader
     {
-        public struct BinaryHeader
-        {
-            public byte[] Type;
-            public byte[] SubType;
-            public uint Version;
-            public byte EndianType;
-            public byte AlignmentBits;
-            public ushort Offset;
-            public ulong Size;
-            public ulong DateTime;
-            private uint _reserved1;
-            private uint _reserved2;
-            private uint _reserved3;
-            private uint _reserved4;
+        public byte[] Type;
+        public byte[] SubType;
+        public uint Version;
+        public byte EndianType;
+        public byte AlignmentBits;
+        public ushort Offset;
+        public ulong Size;
+        public ulong DateTime;
+        private uint _reserved1;
+        private uint _reserved2;
+        private uint _reserved3;
+        private uint _reserved4;
 
-            public BinaryHeader( LuminaBinaryReader binaryReader )
+        public BinaryHeader( LuminaBinaryReader binaryReader )
+        {
+            Type = binaryReader.ReadBytes( 4 );
+            SubType = binaryReader.ReadBytes( 4 );
+            Version = binaryReader.ReadUInt32();
+            EndianType = binaryReader.ReadByte();
+
+            if( binaryReader.IsLittleEndian != ( EndianType == 0 ) )
             {
-                Type = binaryReader.ReadBytes( 4 );
-                SubType = binaryReader.ReadBytes( 4 );
-                Version = binaryReader.ReadUInt32();
-                EndianType = binaryReader.ReadByte();
-
-                if( binaryReader.IsLittleEndian != ( EndianType == 0 ) )
-                {
-                    Version = BinaryPrimitives.ReverseEndianness( Version );
-                    binaryReader.IsLittleEndian = EndianType == 0;
-                }
-
-                AlignmentBits = binaryReader.ReadByte();
-                Offset = binaryReader.ReadUInt16();
-                Size = binaryReader.ReadUInt64();
-                DateTime = binaryReader.ReadUInt64();
-                _reserved1 = binaryReader.ReadUInt32();
-                _reserved2 = binaryReader.ReadUInt32();
-                _reserved3 = binaryReader.ReadUInt32();
-                _reserved4 = binaryReader.ReadUInt32();
+                Version = BinaryPrimitives.ReverseEndianness( Version );
+                binaryReader.IsLittleEndian = EndianType == 0;
             }
-        }
 
-        public struct ScdHeader
-        {
-            public ushort SoundCount;
-            public ushort TrackCount;
-            public ushort AudioCount;
-            public ushort Number;
-            public uint TrackOffset;
-            public uint AudioOffset;
-            public uint LayoutOffset;
-            public uint RoutingOffset;
-            public uint AttributeOffset;
-            public ushort EOFPaddingSize;
-            private ushort _reserve16;
+            AlignmentBits = binaryReader.ReadByte();
+            Offset = binaryReader.ReadUInt16();
+            Size = binaryReader.ReadUInt64();
+            DateTime = binaryReader.ReadUInt64();
+            _reserved1 = binaryReader.ReadUInt32();
+            _reserved2 = binaryReader.ReadUInt32();
+            _reserved3 = binaryReader.ReadUInt32();
+            _reserved4 = binaryReader.ReadUInt32();
         }
+    }
+
+    public struct ScdHeader
+    {
+        public ushort SoundCount;
+        public ushort TrackCount;
+        public ushort AudioCount;
+        public ushort Number;
+        public uint TrackOffset;
+        public uint AudioOffset;
+        public uint LayoutOffset;
+        public uint RoutingOffset;
+        public uint AttributeOffset;
+        public ushort EOFPaddingSize;
+        private ushort _reserve16;
     }
 }

--- a/src/Lumina/Data/Parsing/Scd/ScdCommon.cs
+++ b/src/Lumina/Data/Parsing/Scd/ScdCommon.cs
@@ -1,0 +1,64 @@
+using System.Buffers.Binary;
+
+#pragma warning disable CS0169
+#pragma warning disable CS1591
+
+namespace Lumina.Data.Parsing.Scd
+{
+    public static class ScdCommon
+    {
+        public struct BinaryHeader
+        {
+            public byte[] Type;
+            public byte[] SubType;
+            public uint Version;
+            public byte EndianType;
+            public byte AlignmentBits;
+            public ushort Offset;
+            public ulong Size;
+            public ulong DateTime;
+            private uint _reserved1;
+            private uint _reserved2;
+            private uint _reserved3;
+            private uint _reserved4;
+
+            public BinaryHeader( LuminaBinaryReader binaryReader )
+            {
+                Type = binaryReader.ReadBytes( 4 );
+                SubType = binaryReader.ReadBytes( 4 );
+                Version = binaryReader.ReadUInt32();
+                EndianType = binaryReader.ReadByte();
+
+                if( binaryReader.IsLittleEndian != ( EndianType == 0 ) )
+                {
+                    Version = BinaryPrimitives.ReverseEndianness( Version );
+                    binaryReader.IsLittleEndian = EndianType == 0;
+                }
+
+                AlignmentBits = binaryReader.ReadByte();
+                Offset = binaryReader.ReadUInt16();
+                Size = binaryReader.ReadUInt64();
+                DateTime = binaryReader.ReadUInt64();
+                _reserved1 = binaryReader.ReadUInt32();
+                _reserved2 = binaryReader.ReadUInt32();
+                _reserved3 = binaryReader.ReadUInt32();
+                _reserved4 = binaryReader.ReadUInt32();
+            }
+        }
+
+        public struct ScdHeader
+        {
+            public ushort SoundCount;
+            public ushort TrackCount;
+            public ushort AudioCount;
+            public ushort Number;
+            public uint TrackOffset;
+            public uint AudioOffset;
+            public uint LayoutOffset;
+            public uint RoutingOffset;
+            public uint AttributeOffset;
+            public ushort EOFPaddingSize;
+            private ushort _reserve16;
+        }
+    }
+}

--- a/src/Lumina/Data/Parsing/Scd/ScdLayout.cs
+++ b/src/Lumina/Data/Parsing/Scd/ScdLayout.cs
@@ -1,0 +1,579 @@
+using System.Numerics;
+
+#pragma warning disable CS1591
+
+namespace Lumina.Data.Parsing.Scd
+{
+    public static class ScdLayout
+    {
+        public enum SoundObjectType : byte
+        {
+            Null,
+            Ambient,
+            Direction,
+            Point,
+            PointDir,
+            Line,
+            Polyline,
+            Surface,
+            BoardObstruction,
+            BoxObstruction,
+            PolylineObstruction,
+            Polygon,
+            BoxExtController,
+            LineExtController,
+            PolygonObstruction
+        }
+
+        public struct SoundObject
+        {
+            public ushort Size;
+            public SoundObjectType Type;
+            public byte Version;
+
+            private byte _flags1;
+            public bool UseFixedDirection => ( _flags1 & 0x01 ) != 0;
+            public bool UnboundedDistance => ( _flags1 & 0x02 ) != 0;
+            public bool FirstInactive => ( _flags1 & 0x04 ) != 0;
+            public bool BottomInfinity => ( _flags1 & 0x08 ) != 0;
+            public bool TopInfinity => ( _flags1 & 0x10 ) != 0;
+            public bool Flag3D => ( _flags1 & 0x20 ) != 0;
+            public bool PointExpansion => ( _flags1 & 0x40 ) != 0;
+            public bool IsLittleEndian => ( _flags1 & 0x80 ) != 0;
+
+            public byte GroupNo;
+            public ushort LocalId;
+            public uint BankId;
+
+            private byte _flags2;
+            public bool IsMaxRangeInterior => ( _flags2 & 0x01 ) != 0;
+            public bool UseDistanceFilters => ( _flags2 & 0x02 ) != 0;
+            public bool UseDirFirstPos => ( _flags2 & 0x04 ) != 0;
+            public bool IsWooferOnly => ( _flags2 & 0x08 ) != 0;
+            public bool IsFixedVolume => ( _flags2 & 0x10 ) != 0;
+            public bool IsIgnoreObstruction => ( _flags2 & 0x20 ) != 0;
+            public bool IsFirstFixedDirection => ( _flags2 & 0x40 ) != 0;
+            public bool IsLocalFixedDirection => ( _flags2 & 0x80 ) != 0;
+
+            public byte ReverbType;
+            public ushort AbGroupNo;
+            public float[] ArrayVolume;
+
+            public object? Data;
+
+            public SoundObject( LuminaBinaryReader binaryReader )
+            {
+                Size = binaryReader.ReadUInt16();
+                Type = (SoundObjectType)binaryReader.ReadByte();
+                Version = binaryReader.ReadByte();
+                _flags1 = binaryReader.ReadByte();
+                GroupNo = binaryReader.ReadByte();
+                LocalId = binaryReader.ReadUInt16();
+                BankId = binaryReader.ReadUInt32();
+                _flags2 = binaryReader.ReadByte();
+                ReverbType = binaryReader.ReadByte();
+                AbGroupNo = binaryReader.ReadUInt16();
+                ArrayVolume = binaryReader.ReadSingleArray( 4 );
+
+                switch( Type )
+                {
+                    case SoundObjectType.Ambient:
+                        Data = new SoundObjectAmbientSound( binaryReader );
+                        break;
+
+                    case SoundObjectType.Direction:
+                        Data = new SoundObjectDirectionSound( binaryReader );
+                        break;
+
+                    case SoundObjectType.Point:
+                        Data = new SoundObjectPointSound( binaryReader );
+                        break;
+
+                    case SoundObjectType.PointDir:
+                        Data = new SoundObjectPointDirSound( binaryReader );
+                        break;
+
+                    case SoundObjectType.Line:
+                        Data = new SoundObjectLineSound( binaryReader );
+                        break;
+
+                    case SoundObjectType.Polyline:
+                        Data = new SoundObjectPolyLineSound( binaryReader );
+                        break;
+
+                    case SoundObjectType.Surface:
+                        Data = new SoundObjectSurfaceSound( binaryReader );
+                        break;
+
+                    case SoundObjectType.BoardObstruction:
+                        Data = new SoundObjectBoardObstruction( binaryReader );
+                        break;
+
+                    case SoundObjectType.BoxObstruction:
+                        Data = new SoundObjectBoxObstruction( binaryReader );
+                        break;
+
+                    case SoundObjectType.PolylineObstruction:
+                        Data = new SoundObjectPolyLineObstruction( binaryReader );
+                        break;
+
+                    case SoundObjectType.Polygon:
+                        Data = new SoundObjectPolygonSound( binaryReader );
+                        break;
+
+                    case SoundObjectType.LineExtController:
+                        Data = new SoundObjectLineExtController( binaryReader );
+                        break;
+
+                    case SoundObjectType.PolygonObstruction:
+                        Data = new SoundObjectPolygonObstruction( binaryReader );
+                        break;
+
+                    case SoundObjectType.Null:
+                    case SoundObjectType.BoxExtController:
+                    default:
+                        Data = null;
+                        break;
+                }
+            }
+        }
+
+        public struct SoundObjectAmbientSound
+        {
+            public float Volume;
+            public float Pitch;
+            public float ReverbFac;
+            public float[] DirectVolume;
+            private uint _reserved_i;
+
+            public SoundObjectAmbientSound( LuminaBinaryReader binaryReader )
+            {
+                Volume = binaryReader.ReadSingle();
+                Pitch = binaryReader.ReadSingle();
+                ReverbFac = binaryReader.ReadSingle();
+                DirectVolume = binaryReader.ReadSingleArray( 8 );
+                _reserved_i = binaryReader.ReadUInt32();
+            }
+        }
+
+        public struct SoundObjectDirectionSound
+        {
+            public float Volume;
+            public float Pitch;
+            public float ReverbFac;
+            public float Direction;
+            public float RotSpeed;
+            private uint[] _reserved_i;
+
+            public SoundObjectDirectionSound( LuminaBinaryReader binaryReader )
+            {
+                Volume = binaryReader.ReadSingle();
+                Pitch = binaryReader.ReadSingle();
+                ReverbFac = binaryReader.ReadSingle();
+                Direction = binaryReader.ReadSingle();
+                RotSpeed = binaryReader.ReadSingle();
+                _reserved_i = binaryReader.ReadUInt32Array( 3 );
+            }
+        }
+
+        public struct SoundObjectPointSound
+        {
+            public Vector4 Position;
+            public float MaxRange;
+            public float MinRange;
+            public float[] Height;
+            public float RangeVolume;
+            public float Volume;
+            public float Pitch;
+            public float ReverbFac;
+            public float DopplerFac;
+            public float CenterFac;
+            public float InteriorFac;
+            public float Direction;
+            public float NearFadeStart;
+            public float NearFadeEnd;
+            public float FarDelayFac;
+
+            private byte _environmentFlags;
+            public byte EnvironmentType => (byte)( _environmentFlags & 0x3F );
+            public bool IsUseEnvFilterDepth => ( _environmentFlags & 0x40 ) != 0;
+            public bool IsFireWorks => ( _environmentFlags & 0x80 ) != 0;
+
+            private byte _flags;
+            public bool IsReverbObject => ( _flags & 0x40 ) != 0;
+            public bool IsWhizGenerate => ( _flags & 0x80 ) != 0;
+
+            private byte[] _reserved_c;
+            public float LowerLimit;
+            public ushort FadeInTime;
+            public ushort FadeOutTime;
+            public float ConvergenceFac;
+            private uint _reserved_i;
+
+            public SoundObjectPointSound( LuminaBinaryReader binaryReader )
+            {
+                Position = binaryReader.ReadStructure< Vector4 >();
+                MaxRange = binaryReader.ReadSingle();
+                MinRange = binaryReader.ReadSingle();
+                Height = binaryReader.ReadSingleArray( 2 );
+                RangeVolume = binaryReader.ReadSingle();
+                Volume = binaryReader.ReadSingle();
+                Pitch = binaryReader.ReadSingle();
+                ReverbFac = binaryReader.ReadSingle();
+                DopplerFac = binaryReader.ReadSingle();
+                CenterFac = binaryReader.ReadSingle();
+                InteriorFac = binaryReader.ReadSingle();
+                Direction = binaryReader.ReadSingle();
+                NearFadeStart = binaryReader.ReadSingle();
+                NearFadeEnd = binaryReader.ReadSingle();
+                FarDelayFac = binaryReader.ReadSingle();
+                _environmentFlags = binaryReader.ReadByte();
+                _flags = binaryReader.ReadByte();
+                _reserved_c = binaryReader.ReadBytes( 2 );
+                LowerLimit = binaryReader.ReadSingle();
+                FadeInTime = binaryReader.ReadUInt16();
+                FadeOutTime = binaryReader.ReadUInt16();
+                ConvergenceFac = binaryReader.ReadSingle();
+                _reserved_i = binaryReader.ReadUInt32();
+            }
+        }
+
+        public struct SoundObjectPointDirSound
+        {
+            public Vector4 Position;
+            public Vector4 Direction;
+            public float RangeX;
+            public float RangeY;
+            public float MaxRange;
+            public float MinRange;
+            public float[] Height;
+            public float RangeVolume;
+            public float Volume;
+            public float Pitch;
+            public float ReverbFac;
+            public float DopplerFac;
+            public float InteriorFac;
+            public float FixedDirection;
+            private uint[] _reserved_i;
+
+            public SoundObjectPointDirSound( LuminaBinaryReader binaryReader )
+            {
+                Position = binaryReader.ReadStructure< Vector4 >();
+                Direction = binaryReader.ReadStructure< Vector4 >();
+                RangeX = binaryReader.ReadSingle();
+                RangeY = binaryReader.ReadSingle();
+                MaxRange = binaryReader.ReadSingle();
+                MinRange = binaryReader.ReadSingle();
+                Height = binaryReader.ReadSingleArray( 2 );
+                RangeVolume = binaryReader.ReadSingle();
+                Volume = binaryReader.ReadSingle();
+                Pitch = binaryReader.ReadSingle();
+                ReverbFac = binaryReader.ReadSingle();
+                DopplerFac = binaryReader.ReadSingle();
+                InteriorFac = binaryReader.ReadSingle();
+                FixedDirection = binaryReader.ReadSingle();
+                _reserved_i = binaryReader.ReadUInt32Array( 3 );
+            }
+        }
+
+        public struct SoundObjectLineSound
+        {
+            public Vector4[] Position;
+            public float MaxRange;
+            public float MinRange;
+            public float[] Height;
+            public float RangeVolume;
+            public float Volume;
+            public float Pitch;
+            public float ReverbFac;
+            public float DopplerFac;
+            public float InteriorFac;
+            public float Direction;
+            private uint _reserved_i;
+
+            public SoundObjectLineSound( LuminaBinaryReader binaryReader )
+            {
+                Position = binaryReader.ReadStructuresAsArray< Vector4 >( 2 );
+                MaxRange = binaryReader.ReadSingle();
+                MinRange = binaryReader.ReadSingle();
+                Height = binaryReader.ReadSingleArray( 2 );
+                RangeVolume = binaryReader.ReadSingle();
+                Volume = binaryReader.ReadSingle();
+                Pitch = binaryReader.ReadSingle();
+                ReverbFac = binaryReader.ReadSingle();
+                DopplerFac = binaryReader.ReadSingle();
+                InteriorFac = binaryReader.ReadSingle();
+                Direction = binaryReader.ReadSingle();
+                _reserved_i = binaryReader.ReadUInt32();
+            }
+        }
+
+        public struct SoundObjectPolyLineSound
+        {
+            public Vector4[] Position;
+            public float MaxRange;
+            public float MinRange;
+            public float[] Height;
+            public float RangeVolume;
+            public float Volume;
+            public float Pitch;
+            public float ReverbFac;
+            public float DopplerFac;
+            public byte VertexCount;
+            private byte[] _reserved_c;
+            public float InteriorFac;
+            public float Direction;
+
+            public SoundObjectPolyLineSound( LuminaBinaryReader binaryReader )
+            {
+                Position = binaryReader.ReadStructuresAsArray< Vector4 >( 16 );
+                MaxRange = binaryReader.ReadSingle();
+                MinRange = binaryReader.ReadSingle();
+                Height = binaryReader.ReadSingleArray( 2 );
+                RangeVolume = binaryReader.ReadSingle();
+                Volume = binaryReader.ReadSingle();
+                Pitch = binaryReader.ReadSingle();
+                ReverbFac = binaryReader.ReadSingle();
+                DopplerFac = binaryReader.ReadSingle();
+                VertexCount = binaryReader.ReadByte();
+                _reserved_c = binaryReader.ReadBytes( 3 );
+                InteriorFac = binaryReader.ReadSingle();
+                Direction = binaryReader.ReadSingle();
+            }
+        }
+
+        public struct SoundObjectSurfaceSound
+        {
+            public Vector4[] Position;
+            public float MaxRange;
+            public float MinRange;
+            public float[] Height;
+            public float RangeVolume;
+            public float Volume;
+            public float Pitch;
+            public float ReverbFac;
+            public float DopplerFac;
+            public float InteriorFac;
+            public float Direction;
+            public byte SubSoundType;
+
+            private byte _flags;
+            public bool IsReverbObject => ( _flags & 0x80 ) != 0;
+
+            private byte[] _reserved_c;
+            public float RotSpeed;
+            private uint[] _reserved_i;
+
+            public SoundObjectSurfaceSound( LuminaBinaryReader binaryReader )
+            {
+                Position = binaryReader.ReadStructuresAsArray< Vector4 >( 4 );
+                MaxRange = binaryReader.ReadSingle();
+                MinRange = binaryReader.ReadSingle();
+                Height = binaryReader.ReadSingleArray( 2 );
+                RangeVolume = binaryReader.ReadSingle();
+                Volume = binaryReader.ReadSingle();
+                Pitch = binaryReader.ReadSingle();
+                ReverbFac = binaryReader.ReadSingle();
+                DopplerFac = binaryReader.ReadSingle();
+                InteriorFac = binaryReader.ReadSingle();
+                Direction = binaryReader.ReadSingle();
+                SubSoundType = binaryReader.ReadByte();
+                _flags = binaryReader.ReadByte();
+                _reserved_c = binaryReader.ReadBytes( 2 );
+                RotSpeed = binaryReader.ReadSingle();
+                _reserved_i = binaryReader.ReadUInt32Array( 3 );
+            }
+        }
+
+        public struct SoundObjectBoardObstruction
+        {
+            public Vector4[] Position;
+            public float ObstacleFac;
+            public float HiCutFac;
+
+            private byte _flags;
+            public bool UseHiCutFac => ( _flags & 0x08 ) != 0;
+
+            private byte[] _reserved_c;
+            public ushort OpenTime;
+            public ushort CloseTime;
+
+            public SoundObjectBoardObstruction( LuminaBinaryReader binaryReader )
+            {
+                Position = binaryReader.ReadStructuresAsArray< Vector4 >( 4 );
+                ObstacleFac = binaryReader.ReadSingle();
+                HiCutFac = binaryReader.ReadSingle();
+                _flags = binaryReader.ReadByte();
+                _reserved_c = binaryReader.ReadBytes( 3 );
+                OpenTime = binaryReader.ReadUInt16();
+                CloseTime = binaryReader.ReadUInt16();
+            }
+        }
+
+        public struct SoundObjectBoxObstruction
+        {
+            public Vector4[] Position;
+            public float[] Height;
+            public float ObstacleFac;
+            public float HicutFac;
+
+            private byte _flags;
+            public bool UseHiCutFac => ( _flags & 0x08 ) != 0;
+
+            private byte[] _reserved_c;
+            public float FadeRange;
+            public ushort OpenTime;
+            public ushort CloseTime;
+            private uint _reserved_i;
+
+            public SoundObjectBoxObstruction( LuminaBinaryReader binaryReader )
+            {
+                Position = binaryReader.ReadStructuresAsArray< Vector4 >( 4 );
+                Height = binaryReader.ReadSingleArray( 2 );
+                ObstacleFac = binaryReader.ReadSingle();
+                HicutFac = binaryReader.ReadSingle();
+                _flags = binaryReader.ReadByte();
+                _reserved_c = binaryReader.ReadBytes( 3 );
+                FadeRange = binaryReader.ReadSingle();
+                OpenTime = binaryReader.ReadUInt16();
+                CloseTime = binaryReader.ReadUInt16();
+                _reserved_i = binaryReader.ReadUInt32();
+            }
+        }
+
+        public struct SoundObjectPolyLineObstruction
+        {
+            public Vector4[] Position;
+            public float[] Height;
+            public float ObstacleFac;
+            public float HiCutFac;
+
+            private byte _flags;
+            public bool UseHiCutFac => ( _flags & 0x08 ) != 0;
+
+            public byte VertexCount;
+            private byte[] _reserved_c;
+            public float Width;
+            public float FadeRange;
+            public ushort OpenTime;
+            public ushort CloseTime;
+
+            public SoundObjectPolyLineObstruction( LuminaBinaryReader binaryReader )
+            {
+                Position = binaryReader.ReadStructuresAsArray< Vector4 >( 16 );
+                Height = binaryReader.ReadSingleArray( 2 );
+                ObstacleFac = binaryReader.ReadSingle();
+                HiCutFac = binaryReader.ReadSingle();
+                _flags = binaryReader.ReadByte();
+                VertexCount = binaryReader.ReadByte();
+                _reserved_c = binaryReader.ReadBytes( 2 );
+                Width = binaryReader.ReadSingle();
+                FadeRange = binaryReader.ReadSingle();
+                OpenTime = binaryReader.ReadUInt16();
+                CloseTime = binaryReader.ReadUInt16();
+            }
+        }
+
+        public struct SoundObjectPolygonSound
+        {
+            public float MaxRange;
+            public float MinRange;
+            public float[] Height;
+            public float RangeVolume;
+            public float Volume;
+            public float Pitch;
+            public float ReverbFac;
+            public float DopplerFac;
+            public float InteriorFac;
+            public float Direction;
+            public byte SubSoundType;
+
+            private byte _flags;
+            public bool IsReverbObject => ( _flags & 0x80 ) != 0;
+
+            public byte VertexCount;
+            private byte _reserved_c;
+            public float RotSpeed;
+            private uint[] _reserved_i;
+            public Vector4[] Position;
+
+            public SoundObjectPolygonSound( LuminaBinaryReader binaryReader )
+            {
+                MaxRange = binaryReader.ReadSingle();
+                MinRange = binaryReader.ReadSingle();
+                Height = binaryReader.ReadSingleArray( 2 );
+                RangeVolume = binaryReader.ReadSingle();
+                Volume = binaryReader.ReadSingle();
+                Pitch = binaryReader.ReadSingle();
+                ReverbFac = binaryReader.ReadSingle();
+                DopplerFac = binaryReader.ReadSingle();
+                InteriorFac = binaryReader.ReadSingle();
+                Direction = binaryReader.ReadSingle();
+                SubSoundType = binaryReader.ReadByte();
+                _flags = binaryReader.ReadByte();
+                VertexCount = binaryReader.ReadByte();
+                _reserved_c = binaryReader.ReadByte();
+                RotSpeed = binaryReader.ReadSingle();
+                _reserved_i = binaryReader.ReadUInt32Array( 3 );
+                Position = binaryReader.ReadStructuresAsArray< Vector4 >( 32 );
+            }
+        }
+
+        public struct SoundObjectLineExtController
+        {
+            public Vector4[] Position;
+            public float MaxRange;
+            public float MinRange;
+            public float[] Height;
+            public float RangeVolume;
+            public float Volume;
+            public float LowerLimit;
+            public uint FuncNo;
+            public byte CalcType;
+            private byte[] _reserved_c;
+            private uint[] _reserved_i;
+
+            public SoundObjectLineExtController( LuminaBinaryReader binaryReader )
+            {
+                Position = binaryReader.ReadStructuresAsArray< Vector4 >( 2 );
+                MaxRange = binaryReader.ReadSingle();
+                MinRange = binaryReader.ReadSingle();
+                Height = binaryReader.ReadSingleArray( 2 );
+                RangeVolume = binaryReader.ReadSingle();
+                Volume = binaryReader.ReadSingle();
+                LowerLimit = binaryReader.ReadSingle();
+                FuncNo = binaryReader.ReadUInt32();
+                CalcType = binaryReader.ReadByte();
+                _reserved_c = binaryReader.ReadBytes( 3 );
+                _reserved_i = binaryReader.ReadUInt32Array( 4 );
+            }
+        }
+
+        public struct SoundObjectPolygonObstruction
+        {
+            public Vector4[] Position;
+            public float ObstacleFac;
+            public float HiCutFac;
+
+            private byte _flags;
+            public bool UseHiCutFac => ( _flags & 0x08 ) != 0;
+
+            public byte VertexCount;
+            private byte[] _reserved_c;
+            public ushort OpenTime;
+            public ushort CloseTime;
+
+            public SoundObjectPolygonObstruction( LuminaBinaryReader binaryReader )
+            {
+                Position = binaryReader.ReadStructuresAsArray< Vector4 >( 32 );
+                ObstacleFac = binaryReader.ReadSingle();
+                HiCutFac = binaryReader.ReadSingle();
+                _flags = binaryReader.ReadByte();
+                VertexCount = binaryReader.ReadByte();
+                _reserved_c = binaryReader.ReadBytes( 2 );
+                OpenTime = binaryReader.ReadUInt16();
+                CloseTime = binaryReader.ReadUInt16();
+            }
+        }
+    }
+}

--- a/src/Lumina/Data/Parsing/Scd/ScdLayout.cs
+++ b/src/Lumina/Data/Parsing/Scd/ScdLayout.cs
@@ -4,576 +4,573 @@ using System.Numerics;
 
 namespace Lumina.Data.Parsing.Scd
 {
-    public static class ScdLayout
+    public enum SoundObjectType : byte
     {
-        public enum SoundObjectType : byte
+        Null,
+        Ambient,
+        Direction,
+        Point,
+        PointDir,
+        Line,
+        Polyline,
+        Surface,
+        BoardObstruction,
+        BoxObstruction,
+        PolylineObstruction,
+        Polygon,
+        BoxExtController,
+        LineExtController,
+        PolygonObstruction
+    }
+
+    public struct SoundObject
+    {
+        public ushort Size;
+        public SoundObjectType Type;
+        public byte Version;
+
+        private byte _flags1;
+        public bool UseFixedDirection => ( _flags1 & 0x01 ) != 0;
+        public bool UnboundedDistance => ( _flags1 & 0x02 ) != 0;
+        public bool FirstInactive => ( _flags1 & 0x04 ) != 0;
+        public bool BottomInfinity => ( _flags1 & 0x08 ) != 0;
+        public bool TopInfinity => ( _flags1 & 0x10 ) != 0;
+        public bool Flag3D => ( _flags1 & 0x20 ) != 0;
+        public bool PointExpansion => ( _flags1 & 0x40 ) != 0;
+        public bool IsLittleEndian => ( _flags1 & 0x80 ) != 0;
+
+        public byte GroupNo;
+        public ushort LocalId;
+        public uint BankId;
+
+        private byte _flags2;
+        public bool IsMaxRangeInterior => ( _flags2 & 0x01 ) != 0;
+        public bool UseDistanceFilters => ( _flags2 & 0x02 ) != 0;
+        public bool UseDirFirstPos => ( _flags2 & 0x04 ) != 0;
+        public bool IsWooferOnly => ( _flags2 & 0x08 ) != 0;
+        public bool IsFixedVolume => ( _flags2 & 0x10 ) != 0;
+        public bool IsIgnoreObstruction => ( _flags2 & 0x20 ) != 0;
+        public bool IsFirstFixedDirection => ( _flags2 & 0x40 ) != 0;
+        public bool IsLocalFixedDirection => ( _flags2 & 0x80 ) != 0;
+
+        public byte ReverbType;
+        public ushort AbGroupNo;
+        public float[] ArrayVolume;
+
+        public object? Data;
+
+        public SoundObject( LuminaBinaryReader binaryReader )
         {
-            Null,
-            Ambient,
-            Direction,
-            Point,
-            PointDir,
-            Line,
-            Polyline,
-            Surface,
-            BoardObstruction,
-            BoxObstruction,
-            PolylineObstruction,
-            Polygon,
-            BoxExtController,
-            LineExtController,
-            PolygonObstruction
-        }
+            Size = binaryReader.ReadUInt16();
+            Type = (SoundObjectType)binaryReader.ReadByte();
+            Version = binaryReader.ReadByte();
+            _flags1 = binaryReader.ReadByte();
+            GroupNo = binaryReader.ReadByte();
+            LocalId = binaryReader.ReadUInt16();
+            BankId = binaryReader.ReadUInt32();
+            _flags2 = binaryReader.ReadByte();
+            ReverbType = binaryReader.ReadByte();
+            AbGroupNo = binaryReader.ReadUInt16();
+            ArrayVolume = binaryReader.ReadSingleArray( 4 );
 
-        public struct SoundObject
-        {
-            public ushort Size;
-            public SoundObjectType Type;
-            public byte Version;
-
-            private byte _flags1;
-            public bool UseFixedDirection => ( _flags1 & 0x01 ) != 0;
-            public bool UnboundedDistance => ( _flags1 & 0x02 ) != 0;
-            public bool FirstInactive => ( _flags1 & 0x04 ) != 0;
-            public bool BottomInfinity => ( _flags1 & 0x08 ) != 0;
-            public bool TopInfinity => ( _flags1 & 0x10 ) != 0;
-            public bool Flag3D => ( _flags1 & 0x20 ) != 0;
-            public bool PointExpansion => ( _flags1 & 0x40 ) != 0;
-            public bool IsLittleEndian => ( _flags1 & 0x80 ) != 0;
-
-            public byte GroupNo;
-            public ushort LocalId;
-            public uint BankId;
-
-            private byte _flags2;
-            public bool IsMaxRangeInterior => ( _flags2 & 0x01 ) != 0;
-            public bool UseDistanceFilters => ( _flags2 & 0x02 ) != 0;
-            public bool UseDirFirstPos => ( _flags2 & 0x04 ) != 0;
-            public bool IsWooferOnly => ( _flags2 & 0x08 ) != 0;
-            public bool IsFixedVolume => ( _flags2 & 0x10 ) != 0;
-            public bool IsIgnoreObstruction => ( _flags2 & 0x20 ) != 0;
-            public bool IsFirstFixedDirection => ( _flags2 & 0x40 ) != 0;
-            public bool IsLocalFixedDirection => ( _flags2 & 0x80 ) != 0;
-
-            public byte ReverbType;
-            public ushort AbGroupNo;
-            public float[] ArrayVolume;
-
-            public object? Data;
-
-            public SoundObject( LuminaBinaryReader binaryReader )
+            switch( Type )
             {
-                Size = binaryReader.ReadUInt16();
-                Type = (SoundObjectType)binaryReader.ReadByte();
-                Version = binaryReader.ReadByte();
-                _flags1 = binaryReader.ReadByte();
-                GroupNo = binaryReader.ReadByte();
-                LocalId = binaryReader.ReadUInt16();
-                BankId = binaryReader.ReadUInt32();
-                _flags2 = binaryReader.ReadByte();
-                ReverbType = binaryReader.ReadByte();
-                AbGroupNo = binaryReader.ReadUInt16();
-                ArrayVolume = binaryReader.ReadSingleArray( 4 );
+                case SoundObjectType.Ambient:
+                    Data = new SoundObjectAmbientSound( binaryReader );
+                    break;
 
-                switch( Type )
-                {
-                    case SoundObjectType.Ambient:
-                        Data = new SoundObjectAmbientSound( binaryReader );
-                        break;
+                case SoundObjectType.Direction:
+                    Data = new SoundObjectDirectionSound( binaryReader );
+                    break;
 
-                    case SoundObjectType.Direction:
-                        Data = new SoundObjectDirectionSound( binaryReader );
-                        break;
+                case SoundObjectType.Point:
+                    Data = new SoundObjectPointSound( binaryReader );
+                    break;
 
-                    case SoundObjectType.Point:
-                        Data = new SoundObjectPointSound( binaryReader );
-                        break;
+                case SoundObjectType.PointDir:
+                    Data = new SoundObjectPointDirSound( binaryReader );
+                    break;
 
-                    case SoundObjectType.PointDir:
-                        Data = new SoundObjectPointDirSound( binaryReader );
-                        break;
+                case SoundObjectType.Line:
+                    Data = new SoundObjectLineSound( binaryReader );
+                    break;
 
-                    case SoundObjectType.Line:
-                        Data = new SoundObjectLineSound( binaryReader );
-                        break;
+                case SoundObjectType.Polyline:
+                    Data = new SoundObjectPolyLineSound( binaryReader );
+                    break;
 
-                    case SoundObjectType.Polyline:
-                        Data = new SoundObjectPolyLineSound( binaryReader );
-                        break;
+                case SoundObjectType.Surface:
+                    Data = new SoundObjectSurfaceSound( binaryReader );
+                    break;
 
-                    case SoundObjectType.Surface:
-                        Data = new SoundObjectSurfaceSound( binaryReader );
-                        break;
+                case SoundObjectType.BoardObstruction:
+                    Data = new SoundObjectBoardObstruction( binaryReader );
+                    break;
 
-                    case SoundObjectType.BoardObstruction:
-                        Data = new SoundObjectBoardObstruction( binaryReader );
-                        break;
+                case SoundObjectType.BoxObstruction:
+                    Data = new SoundObjectBoxObstruction( binaryReader );
+                    break;
 
-                    case SoundObjectType.BoxObstruction:
-                        Data = new SoundObjectBoxObstruction( binaryReader );
-                        break;
+                case SoundObjectType.PolylineObstruction:
+                    Data = new SoundObjectPolyLineObstruction( binaryReader );
+                    break;
 
-                    case SoundObjectType.PolylineObstruction:
-                        Data = new SoundObjectPolyLineObstruction( binaryReader );
-                        break;
+                case SoundObjectType.Polygon:
+                    Data = new SoundObjectPolygonSound( binaryReader );
+                    break;
 
-                    case SoundObjectType.Polygon:
-                        Data = new SoundObjectPolygonSound( binaryReader );
-                        break;
+                case SoundObjectType.LineExtController:
+                    Data = new SoundObjectLineExtController( binaryReader );
+                    break;
 
-                    case SoundObjectType.LineExtController:
-                        Data = new SoundObjectLineExtController( binaryReader );
-                        break;
+                case SoundObjectType.PolygonObstruction:
+                    Data = new SoundObjectPolygonObstruction( binaryReader );
+                    break;
 
-                    case SoundObjectType.PolygonObstruction:
-                        Data = new SoundObjectPolygonObstruction( binaryReader );
-                        break;
-
-                    case SoundObjectType.Null:
-                    case SoundObjectType.BoxExtController:
-                    default:
-                        Data = null;
-                        break;
-                }
+                case SoundObjectType.Null:
+                case SoundObjectType.BoxExtController:
+                default:
+                    Data = null;
+                    break;
             }
         }
+    }
 
-        public struct SoundObjectAmbientSound
+    public struct SoundObjectAmbientSound
+    {
+        public float Volume;
+        public float Pitch;
+        public float ReverbFac;
+        public float[] DirectVolume;
+        private uint _reserved_i;
+
+        public SoundObjectAmbientSound( LuminaBinaryReader binaryReader )
         {
-            public float Volume;
-            public float Pitch;
-            public float ReverbFac;
-            public float[] DirectVolume;
-            private uint _reserved_i;
-
-            public SoundObjectAmbientSound( LuminaBinaryReader binaryReader )
-            {
-                Volume = binaryReader.ReadSingle();
-                Pitch = binaryReader.ReadSingle();
-                ReverbFac = binaryReader.ReadSingle();
-                DirectVolume = binaryReader.ReadSingleArray( 8 );
-                _reserved_i = binaryReader.ReadUInt32();
-            }
+            Volume = binaryReader.ReadSingle();
+            Pitch = binaryReader.ReadSingle();
+            ReverbFac = binaryReader.ReadSingle();
+            DirectVolume = binaryReader.ReadSingleArray( 8 );
+            _reserved_i = binaryReader.ReadUInt32();
         }
+    }
 
-        public struct SoundObjectDirectionSound
+    public struct SoundObjectDirectionSound
+    {
+        public float Volume;
+        public float Pitch;
+        public float ReverbFac;
+        public float Direction;
+        public float RotSpeed;
+        private uint[] _reserved_i;
+
+        public SoundObjectDirectionSound( LuminaBinaryReader binaryReader )
         {
-            public float Volume;
-            public float Pitch;
-            public float ReverbFac;
-            public float Direction;
-            public float RotSpeed;
-            private uint[] _reserved_i;
-
-            public SoundObjectDirectionSound( LuminaBinaryReader binaryReader )
-            {
-                Volume = binaryReader.ReadSingle();
-                Pitch = binaryReader.ReadSingle();
-                ReverbFac = binaryReader.ReadSingle();
-                Direction = binaryReader.ReadSingle();
-                RotSpeed = binaryReader.ReadSingle();
-                _reserved_i = binaryReader.ReadUInt32Array( 3 );
-            }
+            Volume = binaryReader.ReadSingle();
+            Pitch = binaryReader.ReadSingle();
+            ReverbFac = binaryReader.ReadSingle();
+            Direction = binaryReader.ReadSingle();
+            RotSpeed = binaryReader.ReadSingle();
+            _reserved_i = binaryReader.ReadUInt32Array( 3 );
         }
+    }
 
-        public struct SoundObjectPointSound
+    public struct SoundObjectPointSound
+    {
+        public Vector4 Position;
+        public float MaxRange;
+        public float MinRange;
+        public float[] Height;
+        public float RangeVolume;
+        public float Volume;
+        public float Pitch;
+        public float ReverbFac;
+        public float DopplerFac;
+        public float CenterFac;
+        public float InteriorFac;
+        public float Direction;
+        public float NearFadeStart;
+        public float NearFadeEnd;
+        public float FarDelayFac;
+
+        private byte _environmentFlags;
+        public byte EnvironmentType => (byte)( _environmentFlags & 0x3F );
+        public bool IsUseEnvFilterDepth => ( _environmentFlags & 0x40 ) != 0;
+        public bool IsFireWorks => ( _environmentFlags & 0x80 ) != 0;
+
+        private byte _flags;
+        public bool IsReverbObject => ( _flags & 0x40 ) != 0;
+        public bool IsWhizGenerate => ( _flags & 0x80 ) != 0;
+
+        private byte[] _reserved_c;
+        public float LowerLimit;
+        public ushort FadeInTime;
+        public ushort FadeOutTime;
+        public float ConvergenceFac;
+        private uint _reserved_i;
+
+        public SoundObjectPointSound( LuminaBinaryReader binaryReader )
         {
-            public Vector4 Position;
-            public float MaxRange;
-            public float MinRange;
-            public float[] Height;
-            public float RangeVolume;
-            public float Volume;
-            public float Pitch;
-            public float ReverbFac;
-            public float DopplerFac;
-            public float CenterFac;
-            public float InteriorFac;
-            public float Direction;
-            public float NearFadeStart;
-            public float NearFadeEnd;
-            public float FarDelayFac;
-
-            private byte _environmentFlags;
-            public byte EnvironmentType => (byte)( _environmentFlags & 0x3F );
-            public bool IsUseEnvFilterDepth => ( _environmentFlags & 0x40 ) != 0;
-            public bool IsFireWorks => ( _environmentFlags & 0x80 ) != 0;
-
-            private byte _flags;
-            public bool IsReverbObject => ( _flags & 0x40 ) != 0;
-            public bool IsWhizGenerate => ( _flags & 0x80 ) != 0;
-
-            private byte[] _reserved_c;
-            public float LowerLimit;
-            public ushort FadeInTime;
-            public ushort FadeOutTime;
-            public float ConvergenceFac;
-            private uint _reserved_i;
-
-            public SoundObjectPointSound( LuminaBinaryReader binaryReader )
-            {
-                Position = binaryReader.ReadStructure< Vector4 >();
-                MaxRange = binaryReader.ReadSingle();
-                MinRange = binaryReader.ReadSingle();
-                Height = binaryReader.ReadSingleArray( 2 );
-                RangeVolume = binaryReader.ReadSingle();
-                Volume = binaryReader.ReadSingle();
-                Pitch = binaryReader.ReadSingle();
-                ReverbFac = binaryReader.ReadSingle();
-                DopplerFac = binaryReader.ReadSingle();
-                CenterFac = binaryReader.ReadSingle();
-                InteriorFac = binaryReader.ReadSingle();
-                Direction = binaryReader.ReadSingle();
-                NearFadeStart = binaryReader.ReadSingle();
-                NearFadeEnd = binaryReader.ReadSingle();
-                FarDelayFac = binaryReader.ReadSingle();
-                _environmentFlags = binaryReader.ReadByte();
-                _flags = binaryReader.ReadByte();
-                _reserved_c = binaryReader.ReadBytes( 2 );
-                LowerLimit = binaryReader.ReadSingle();
-                FadeInTime = binaryReader.ReadUInt16();
-                FadeOutTime = binaryReader.ReadUInt16();
-                ConvergenceFac = binaryReader.ReadSingle();
-                _reserved_i = binaryReader.ReadUInt32();
-            }
+            Position = binaryReader.ReadStructure< Vector4 >();
+            MaxRange = binaryReader.ReadSingle();
+            MinRange = binaryReader.ReadSingle();
+            Height = binaryReader.ReadSingleArray( 2 );
+            RangeVolume = binaryReader.ReadSingle();
+            Volume = binaryReader.ReadSingle();
+            Pitch = binaryReader.ReadSingle();
+            ReverbFac = binaryReader.ReadSingle();
+            DopplerFac = binaryReader.ReadSingle();
+            CenterFac = binaryReader.ReadSingle();
+            InteriorFac = binaryReader.ReadSingle();
+            Direction = binaryReader.ReadSingle();
+            NearFadeStart = binaryReader.ReadSingle();
+            NearFadeEnd = binaryReader.ReadSingle();
+            FarDelayFac = binaryReader.ReadSingle();
+            _environmentFlags = binaryReader.ReadByte();
+            _flags = binaryReader.ReadByte();
+            _reserved_c = binaryReader.ReadBytes( 2 );
+            LowerLimit = binaryReader.ReadSingle();
+            FadeInTime = binaryReader.ReadUInt16();
+            FadeOutTime = binaryReader.ReadUInt16();
+            ConvergenceFac = binaryReader.ReadSingle();
+            _reserved_i = binaryReader.ReadUInt32();
         }
+    }
 
-        public struct SoundObjectPointDirSound
+    public struct SoundObjectPointDirSound
+    {
+        public Vector4 Position;
+        public Vector4 Direction;
+        public float RangeX;
+        public float RangeY;
+        public float MaxRange;
+        public float MinRange;
+        public float[] Height;
+        public float RangeVolume;
+        public float Volume;
+        public float Pitch;
+        public float ReverbFac;
+        public float DopplerFac;
+        public float InteriorFac;
+        public float FixedDirection;
+        private uint[] _reserved_i;
+
+        public SoundObjectPointDirSound( LuminaBinaryReader binaryReader )
         {
-            public Vector4 Position;
-            public Vector4 Direction;
-            public float RangeX;
-            public float RangeY;
-            public float MaxRange;
-            public float MinRange;
-            public float[] Height;
-            public float RangeVolume;
-            public float Volume;
-            public float Pitch;
-            public float ReverbFac;
-            public float DopplerFac;
-            public float InteriorFac;
-            public float FixedDirection;
-            private uint[] _reserved_i;
-
-            public SoundObjectPointDirSound( LuminaBinaryReader binaryReader )
-            {
-                Position = binaryReader.ReadStructure< Vector4 >();
-                Direction = binaryReader.ReadStructure< Vector4 >();
-                RangeX = binaryReader.ReadSingle();
-                RangeY = binaryReader.ReadSingle();
-                MaxRange = binaryReader.ReadSingle();
-                MinRange = binaryReader.ReadSingle();
-                Height = binaryReader.ReadSingleArray( 2 );
-                RangeVolume = binaryReader.ReadSingle();
-                Volume = binaryReader.ReadSingle();
-                Pitch = binaryReader.ReadSingle();
-                ReverbFac = binaryReader.ReadSingle();
-                DopplerFac = binaryReader.ReadSingle();
-                InteriorFac = binaryReader.ReadSingle();
-                FixedDirection = binaryReader.ReadSingle();
-                _reserved_i = binaryReader.ReadUInt32Array( 3 );
-            }
+            Position = binaryReader.ReadStructure< Vector4 >();
+            Direction = binaryReader.ReadStructure< Vector4 >();
+            RangeX = binaryReader.ReadSingle();
+            RangeY = binaryReader.ReadSingle();
+            MaxRange = binaryReader.ReadSingle();
+            MinRange = binaryReader.ReadSingle();
+            Height = binaryReader.ReadSingleArray( 2 );
+            RangeVolume = binaryReader.ReadSingle();
+            Volume = binaryReader.ReadSingle();
+            Pitch = binaryReader.ReadSingle();
+            ReverbFac = binaryReader.ReadSingle();
+            DopplerFac = binaryReader.ReadSingle();
+            InteriorFac = binaryReader.ReadSingle();
+            FixedDirection = binaryReader.ReadSingle();
+            _reserved_i = binaryReader.ReadUInt32Array( 3 );
         }
+    }
 
-        public struct SoundObjectLineSound
+    public struct SoundObjectLineSound
+    {
+        public Vector4[] Position;
+        public float MaxRange;
+        public float MinRange;
+        public float[] Height;
+        public float RangeVolume;
+        public float Volume;
+        public float Pitch;
+        public float ReverbFac;
+        public float DopplerFac;
+        public float InteriorFac;
+        public float Direction;
+        private uint _reserved_i;
+
+        public SoundObjectLineSound( LuminaBinaryReader binaryReader )
         {
-            public Vector4[] Position;
-            public float MaxRange;
-            public float MinRange;
-            public float[] Height;
-            public float RangeVolume;
-            public float Volume;
-            public float Pitch;
-            public float ReverbFac;
-            public float DopplerFac;
-            public float InteriorFac;
-            public float Direction;
-            private uint _reserved_i;
-
-            public SoundObjectLineSound( LuminaBinaryReader binaryReader )
-            {
-                Position = binaryReader.ReadStructuresAsArray< Vector4 >( 2 );
-                MaxRange = binaryReader.ReadSingle();
-                MinRange = binaryReader.ReadSingle();
-                Height = binaryReader.ReadSingleArray( 2 );
-                RangeVolume = binaryReader.ReadSingle();
-                Volume = binaryReader.ReadSingle();
-                Pitch = binaryReader.ReadSingle();
-                ReverbFac = binaryReader.ReadSingle();
-                DopplerFac = binaryReader.ReadSingle();
-                InteriorFac = binaryReader.ReadSingle();
-                Direction = binaryReader.ReadSingle();
-                _reserved_i = binaryReader.ReadUInt32();
-            }
+            Position = binaryReader.ReadStructuresAsArray< Vector4 >( 2 );
+            MaxRange = binaryReader.ReadSingle();
+            MinRange = binaryReader.ReadSingle();
+            Height = binaryReader.ReadSingleArray( 2 );
+            RangeVolume = binaryReader.ReadSingle();
+            Volume = binaryReader.ReadSingle();
+            Pitch = binaryReader.ReadSingle();
+            ReverbFac = binaryReader.ReadSingle();
+            DopplerFac = binaryReader.ReadSingle();
+            InteriorFac = binaryReader.ReadSingle();
+            Direction = binaryReader.ReadSingle();
+            _reserved_i = binaryReader.ReadUInt32();
         }
+    }
 
-        public struct SoundObjectPolyLineSound
+    public struct SoundObjectPolyLineSound
+    {
+        public Vector4[] Position;
+        public float MaxRange;
+        public float MinRange;
+        public float[] Height;
+        public float RangeVolume;
+        public float Volume;
+        public float Pitch;
+        public float ReverbFac;
+        public float DopplerFac;
+        public byte VertexCount;
+        private byte[] _reserved_c;
+        public float InteriorFac;
+        public float Direction;
+
+        public SoundObjectPolyLineSound( LuminaBinaryReader binaryReader )
         {
-            public Vector4[] Position;
-            public float MaxRange;
-            public float MinRange;
-            public float[] Height;
-            public float RangeVolume;
-            public float Volume;
-            public float Pitch;
-            public float ReverbFac;
-            public float DopplerFac;
-            public byte VertexCount;
-            private byte[] _reserved_c;
-            public float InteriorFac;
-            public float Direction;
-
-            public SoundObjectPolyLineSound( LuminaBinaryReader binaryReader )
-            {
-                Position = binaryReader.ReadStructuresAsArray< Vector4 >( 16 );
-                MaxRange = binaryReader.ReadSingle();
-                MinRange = binaryReader.ReadSingle();
-                Height = binaryReader.ReadSingleArray( 2 );
-                RangeVolume = binaryReader.ReadSingle();
-                Volume = binaryReader.ReadSingle();
-                Pitch = binaryReader.ReadSingle();
-                ReverbFac = binaryReader.ReadSingle();
-                DopplerFac = binaryReader.ReadSingle();
-                VertexCount = binaryReader.ReadByte();
-                _reserved_c = binaryReader.ReadBytes( 3 );
-                InteriorFac = binaryReader.ReadSingle();
-                Direction = binaryReader.ReadSingle();
-            }
+            Position = binaryReader.ReadStructuresAsArray< Vector4 >( 16 );
+            MaxRange = binaryReader.ReadSingle();
+            MinRange = binaryReader.ReadSingle();
+            Height = binaryReader.ReadSingleArray( 2 );
+            RangeVolume = binaryReader.ReadSingle();
+            Volume = binaryReader.ReadSingle();
+            Pitch = binaryReader.ReadSingle();
+            ReverbFac = binaryReader.ReadSingle();
+            DopplerFac = binaryReader.ReadSingle();
+            VertexCount = binaryReader.ReadByte();
+            _reserved_c = binaryReader.ReadBytes( 3 );
+            InteriorFac = binaryReader.ReadSingle();
+            Direction = binaryReader.ReadSingle();
         }
+    }
 
-        public struct SoundObjectSurfaceSound
+    public struct SoundObjectSurfaceSound
+    {
+        public Vector4[] Position;
+        public float MaxRange;
+        public float MinRange;
+        public float[] Height;
+        public float RangeVolume;
+        public float Volume;
+        public float Pitch;
+        public float ReverbFac;
+        public float DopplerFac;
+        public float InteriorFac;
+        public float Direction;
+        public byte SubSoundType;
+
+        private byte _flags;
+        public bool IsReverbObject => ( _flags & 0x80 ) != 0;
+
+        private byte[] _reserved_c;
+        public float RotSpeed;
+        private uint[] _reserved_i;
+
+        public SoundObjectSurfaceSound( LuminaBinaryReader binaryReader )
         {
-            public Vector4[] Position;
-            public float MaxRange;
-            public float MinRange;
-            public float[] Height;
-            public float RangeVolume;
-            public float Volume;
-            public float Pitch;
-            public float ReverbFac;
-            public float DopplerFac;
-            public float InteriorFac;
-            public float Direction;
-            public byte SubSoundType;
-
-            private byte _flags;
-            public bool IsReverbObject => ( _flags & 0x80 ) != 0;
-
-            private byte[] _reserved_c;
-            public float RotSpeed;
-            private uint[] _reserved_i;
-
-            public SoundObjectSurfaceSound( LuminaBinaryReader binaryReader )
-            {
-                Position = binaryReader.ReadStructuresAsArray< Vector4 >( 4 );
-                MaxRange = binaryReader.ReadSingle();
-                MinRange = binaryReader.ReadSingle();
-                Height = binaryReader.ReadSingleArray( 2 );
-                RangeVolume = binaryReader.ReadSingle();
-                Volume = binaryReader.ReadSingle();
-                Pitch = binaryReader.ReadSingle();
-                ReverbFac = binaryReader.ReadSingle();
-                DopplerFac = binaryReader.ReadSingle();
-                InteriorFac = binaryReader.ReadSingle();
-                Direction = binaryReader.ReadSingle();
-                SubSoundType = binaryReader.ReadByte();
-                _flags = binaryReader.ReadByte();
-                _reserved_c = binaryReader.ReadBytes( 2 );
-                RotSpeed = binaryReader.ReadSingle();
-                _reserved_i = binaryReader.ReadUInt32Array( 3 );
-            }
+            Position = binaryReader.ReadStructuresAsArray< Vector4 >( 4 );
+            MaxRange = binaryReader.ReadSingle();
+            MinRange = binaryReader.ReadSingle();
+            Height = binaryReader.ReadSingleArray( 2 );
+            RangeVolume = binaryReader.ReadSingle();
+            Volume = binaryReader.ReadSingle();
+            Pitch = binaryReader.ReadSingle();
+            ReverbFac = binaryReader.ReadSingle();
+            DopplerFac = binaryReader.ReadSingle();
+            InteriorFac = binaryReader.ReadSingle();
+            Direction = binaryReader.ReadSingle();
+            SubSoundType = binaryReader.ReadByte();
+            _flags = binaryReader.ReadByte();
+            _reserved_c = binaryReader.ReadBytes( 2 );
+            RotSpeed = binaryReader.ReadSingle();
+            _reserved_i = binaryReader.ReadUInt32Array( 3 );
         }
+    }
 
-        public struct SoundObjectBoardObstruction
+    public struct SoundObjectBoardObstruction
+    {
+        public Vector4[] Position;
+        public float ObstacleFac;
+        public float HiCutFac;
+
+        private byte _flags;
+        public bool UseHiCutFac => ( _flags & 0x08 ) != 0;
+
+        private byte[] _reserved_c;
+        public ushort OpenTime;
+        public ushort CloseTime;
+
+        public SoundObjectBoardObstruction( LuminaBinaryReader binaryReader )
         {
-            public Vector4[] Position;
-            public float ObstacleFac;
-            public float HiCutFac;
-
-            private byte _flags;
-            public bool UseHiCutFac => ( _flags & 0x08 ) != 0;
-
-            private byte[] _reserved_c;
-            public ushort OpenTime;
-            public ushort CloseTime;
-
-            public SoundObjectBoardObstruction( LuminaBinaryReader binaryReader )
-            {
-                Position = binaryReader.ReadStructuresAsArray< Vector4 >( 4 );
-                ObstacleFac = binaryReader.ReadSingle();
-                HiCutFac = binaryReader.ReadSingle();
-                _flags = binaryReader.ReadByte();
-                _reserved_c = binaryReader.ReadBytes( 3 );
-                OpenTime = binaryReader.ReadUInt16();
-                CloseTime = binaryReader.ReadUInt16();
-            }
+            Position = binaryReader.ReadStructuresAsArray< Vector4 >( 4 );
+            ObstacleFac = binaryReader.ReadSingle();
+            HiCutFac = binaryReader.ReadSingle();
+            _flags = binaryReader.ReadByte();
+            _reserved_c = binaryReader.ReadBytes( 3 );
+            OpenTime = binaryReader.ReadUInt16();
+            CloseTime = binaryReader.ReadUInt16();
         }
+    }
 
-        public struct SoundObjectBoxObstruction
+    public struct SoundObjectBoxObstruction
+    {
+        public Vector4[] Position;
+        public float[] Height;
+        public float ObstacleFac;
+        public float HicutFac;
+
+        private byte _flags;
+        public bool UseHiCutFac => ( _flags & 0x08 ) != 0;
+
+        private byte[] _reserved_c;
+        public float FadeRange;
+        public ushort OpenTime;
+        public ushort CloseTime;
+        private uint _reserved_i;
+
+        public SoundObjectBoxObstruction( LuminaBinaryReader binaryReader )
         {
-            public Vector4[] Position;
-            public float[] Height;
-            public float ObstacleFac;
-            public float HicutFac;
-
-            private byte _flags;
-            public bool UseHiCutFac => ( _flags & 0x08 ) != 0;
-
-            private byte[] _reserved_c;
-            public float FadeRange;
-            public ushort OpenTime;
-            public ushort CloseTime;
-            private uint _reserved_i;
-
-            public SoundObjectBoxObstruction( LuminaBinaryReader binaryReader )
-            {
-                Position = binaryReader.ReadStructuresAsArray< Vector4 >( 4 );
-                Height = binaryReader.ReadSingleArray( 2 );
-                ObstacleFac = binaryReader.ReadSingle();
-                HicutFac = binaryReader.ReadSingle();
-                _flags = binaryReader.ReadByte();
-                _reserved_c = binaryReader.ReadBytes( 3 );
-                FadeRange = binaryReader.ReadSingle();
-                OpenTime = binaryReader.ReadUInt16();
-                CloseTime = binaryReader.ReadUInt16();
-                _reserved_i = binaryReader.ReadUInt32();
-            }
+            Position = binaryReader.ReadStructuresAsArray< Vector4 >( 4 );
+            Height = binaryReader.ReadSingleArray( 2 );
+            ObstacleFac = binaryReader.ReadSingle();
+            HicutFac = binaryReader.ReadSingle();
+            _flags = binaryReader.ReadByte();
+            _reserved_c = binaryReader.ReadBytes( 3 );
+            FadeRange = binaryReader.ReadSingle();
+            OpenTime = binaryReader.ReadUInt16();
+            CloseTime = binaryReader.ReadUInt16();
+            _reserved_i = binaryReader.ReadUInt32();
         }
+    }
 
-        public struct SoundObjectPolyLineObstruction
+    public struct SoundObjectPolyLineObstruction
+    {
+        public Vector4[] Position;
+        public float[] Height;
+        public float ObstacleFac;
+        public float HiCutFac;
+
+        private byte _flags;
+        public bool UseHiCutFac => ( _flags & 0x08 ) != 0;
+
+        public byte VertexCount;
+        private byte[] _reserved_c;
+        public float Width;
+        public float FadeRange;
+        public ushort OpenTime;
+        public ushort CloseTime;
+
+        public SoundObjectPolyLineObstruction( LuminaBinaryReader binaryReader )
         {
-            public Vector4[] Position;
-            public float[] Height;
-            public float ObstacleFac;
-            public float HiCutFac;
-
-            private byte _flags;
-            public bool UseHiCutFac => ( _flags & 0x08 ) != 0;
-
-            public byte VertexCount;
-            private byte[] _reserved_c;
-            public float Width;
-            public float FadeRange;
-            public ushort OpenTime;
-            public ushort CloseTime;
-
-            public SoundObjectPolyLineObstruction( LuminaBinaryReader binaryReader )
-            {
-                Position = binaryReader.ReadStructuresAsArray< Vector4 >( 16 );
-                Height = binaryReader.ReadSingleArray( 2 );
-                ObstacleFac = binaryReader.ReadSingle();
-                HiCutFac = binaryReader.ReadSingle();
-                _flags = binaryReader.ReadByte();
-                VertexCount = binaryReader.ReadByte();
-                _reserved_c = binaryReader.ReadBytes( 2 );
-                Width = binaryReader.ReadSingle();
-                FadeRange = binaryReader.ReadSingle();
-                OpenTime = binaryReader.ReadUInt16();
-                CloseTime = binaryReader.ReadUInt16();
-            }
+            Position = binaryReader.ReadStructuresAsArray< Vector4 >( 16 );
+            Height = binaryReader.ReadSingleArray( 2 );
+            ObstacleFac = binaryReader.ReadSingle();
+            HiCutFac = binaryReader.ReadSingle();
+            _flags = binaryReader.ReadByte();
+            VertexCount = binaryReader.ReadByte();
+            _reserved_c = binaryReader.ReadBytes( 2 );
+            Width = binaryReader.ReadSingle();
+            FadeRange = binaryReader.ReadSingle();
+            OpenTime = binaryReader.ReadUInt16();
+            CloseTime = binaryReader.ReadUInt16();
         }
+    }
 
-        public struct SoundObjectPolygonSound
+    public struct SoundObjectPolygonSound
+    {
+        public float MaxRange;
+        public float MinRange;
+        public float[] Height;
+        public float RangeVolume;
+        public float Volume;
+        public float Pitch;
+        public float ReverbFac;
+        public float DopplerFac;
+        public float InteriorFac;
+        public float Direction;
+        public byte SubSoundType;
+
+        private byte _flags;
+        public bool IsReverbObject => ( _flags & 0x80 ) != 0;
+
+        public byte VertexCount;
+        private byte _reserved_c;
+        public float RotSpeed;
+        private uint[] _reserved_i;
+        public Vector4[] Position;
+
+        public SoundObjectPolygonSound( LuminaBinaryReader binaryReader )
         {
-            public float MaxRange;
-            public float MinRange;
-            public float[] Height;
-            public float RangeVolume;
-            public float Volume;
-            public float Pitch;
-            public float ReverbFac;
-            public float DopplerFac;
-            public float InteriorFac;
-            public float Direction;
-            public byte SubSoundType;
-
-            private byte _flags;
-            public bool IsReverbObject => ( _flags & 0x80 ) != 0;
-
-            public byte VertexCount;
-            private byte _reserved_c;
-            public float RotSpeed;
-            private uint[] _reserved_i;
-            public Vector4[] Position;
-
-            public SoundObjectPolygonSound( LuminaBinaryReader binaryReader )
-            {
-                MaxRange = binaryReader.ReadSingle();
-                MinRange = binaryReader.ReadSingle();
-                Height = binaryReader.ReadSingleArray( 2 );
-                RangeVolume = binaryReader.ReadSingle();
-                Volume = binaryReader.ReadSingle();
-                Pitch = binaryReader.ReadSingle();
-                ReverbFac = binaryReader.ReadSingle();
-                DopplerFac = binaryReader.ReadSingle();
-                InteriorFac = binaryReader.ReadSingle();
-                Direction = binaryReader.ReadSingle();
-                SubSoundType = binaryReader.ReadByte();
-                _flags = binaryReader.ReadByte();
-                VertexCount = binaryReader.ReadByte();
-                _reserved_c = binaryReader.ReadByte();
-                RotSpeed = binaryReader.ReadSingle();
-                _reserved_i = binaryReader.ReadUInt32Array( 3 );
-                Position = binaryReader.ReadStructuresAsArray< Vector4 >( 32 );
-            }
+            MaxRange = binaryReader.ReadSingle();
+            MinRange = binaryReader.ReadSingle();
+            Height = binaryReader.ReadSingleArray( 2 );
+            RangeVolume = binaryReader.ReadSingle();
+            Volume = binaryReader.ReadSingle();
+            Pitch = binaryReader.ReadSingle();
+            ReverbFac = binaryReader.ReadSingle();
+            DopplerFac = binaryReader.ReadSingle();
+            InteriorFac = binaryReader.ReadSingle();
+            Direction = binaryReader.ReadSingle();
+            SubSoundType = binaryReader.ReadByte();
+            _flags = binaryReader.ReadByte();
+            VertexCount = binaryReader.ReadByte();
+            _reserved_c = binaryReader.ReadByte();
+            RotSpeed = binaryReader.ReadSingle();
+            _reserved_i = binaryReader.ReadUInt32Array( 3 );
+            Position = binaryReader.ReadStructuresAsArray< Vector4 >( 32 );
         }
+    }
 
-        public struct SoundObjectLineExtController
+    public struct SoundObjectLineExtController
+    {
+        public Vector4[] Position;
+        public float MaxRange;
+        public float MinRange;
+        public float[] Height;
+        public float RangeVolume;
+        public float Volume;
+        public float LowerLimit;
+        public uint FuncNo;
+        public byte CalcType;
+        private byte[] _reserved_c;
+        private uint[] _reserved_i;
+
+        public SoundObjectLineExtController( LuminaBinaryReader binaryReader )
         {
-            public Vector4[] Position;
-            public float MaxRange;
-            public float MinRange;
-            public float[] Height;
-            public float RangeVolume;
-            public float Volume;
-            public float LowerLimit;
-            public uint FuncNo;
-            public byte CalcType;
-            private byte[] _reserved_c;
-            private uint[] _reserved_i;
-
-            public SoundObjectLineExtController( LuminaBinaryReader binaryReader )
-            {
-                Position = binaryReader.ReadStructuresAsArray< Vector4 >( 2 );
-                MaxRange = binaryReader.ReadSingle();
-                MinRange = binaryReader.ReadSingle();
-                Height = binaryReader.ReadSingleArray( 2 );
-                RangeVolume = binaryReader.ReadSingle();
-                Volume = binaryReader.ReadSingle();
-                LowerLimit = binaryReader.ReadSingle();
-                FuncNo = binaryReader.ReadUInt32();
-                CalcType = binaryReader.ReadByte();
-                _reserved_c = binaryReader.ReadBytes( 3 );
-                _reserved_i = binaryReader.ReadUInt32Array( 4 );
-            }
+            Position = binaryReader.ReadStructuresAsArray< Vector4 >( 2 );
+            MaxRange = binaryReader.ReadSingle();
+            MinRange = binaryReader.ReadSingle();
+            Height = binaryReader.ReadSingleArray( 2 );
+            RangeVolume = binaryReader.ReadSingle();
+            Volume = binaryReader.ReadSingle();
+            LowerLimit = binaryReader.ReadSingle();
+            FuncNo = binaryReader.ReadUInt32();
+            CalcType = binaryReader.ReadByte();
+            _reserved_c = binaryReader.ReadBytes( 3 );
+            _reserved_i = binaryReader.ReadUInt32Array( 4 );
         }
+    }
 
-        public struct SoundObjectPolygonObstruction
+    public struct SoundObjectPolygonObstruction
+    {
+        public Vector4[] Position;
+        public float ObstacleFac;
+        public float HiCutFac;
+
+        private byte _flags;
+        public bool UseHiCutFac => ( _flags & 0x08 ) != 0;
+
+        public byte VertexCount;
+        private byte[] _reserved_c;
+        public ushort OpenTime;
+        public ushort CloseTime;
+
+        public SoundObjectPolygonObstruction( LuminaBinaryReader binaryReader )
         {
-            public Vector4[] Position;
-            public float ObstacleFac;
-            public float HiCutFac;
-
-            private byte _flags;
-            public bool UseHiCutFac => ( _flags & 0x08 ) != 0;
-
-            public byte VertexCount;
-            private byte[] _reserved_c;
-            public ushort OpenTime;
-            public ushort CloseTime;
-
-            public SoundObjectPolygonObstruction( LuminaBinaryReader binaryReader )
-            {
-                Position = binaryReader.ReadStructuresAsArray< Vector4 >( 32 );
-                ObstacleFac = binaryReader.ReadSingle();
-                HiCutFac = binaryReader.ReadSingle();
-                _flags = binaryReader.ReadByte();
-                VertexCount = binaryReader.ReadByte();
-                _reserved_c = binaryReader.ReadBytes( 2 );
-                OpenTime = binaryReader.ReadUInt16();
-                CloseTime = binaryReader.ReadUInt16();
-            }
+            Position = binaryReader.ReadStructuresAsArray< Vector4 >( 32 );
+            ObstacleFac = binaryReader.ReadSingle();
+            HiCutFac = binaryReader.ReadSingle();
+            _flags = binaryReader.ReadByte();
+            VertexCount = binaryReader.ReadByte();
+            _reserved_c = binaryReader.ReadBytes( 2 );
+            OpenTime = binaryReader.ReadUInt16();
+            CloseTime = binaryReader.ReadUInt16();
         }
     }
 }

--- a/src/Lumina/Data/Parsing/Scd/ScdSound.cs
+++ b/src/Lumina/Data/Parsing/Scd/ScdSound.cs
@@ -1,0 +1,225 @@
+using System;
+
+#pragma warning disable CS0169
+#pragma warning disable CS1591
+
+namespace Lumina.Data.Parsing.Scd
+{
+    public static class ScdSound
+    {
+        public enum SoundType : byte
+        {
+            Normal = 1,
+            Random,
+            Stereo,
+            Cycle,
+            Order,
+            FourChannelSurround,
+            Engine,
+            Dialog,
+
+            FixedPosition = 10,
+            DynamixStream,
+            GroupRandom,
+            GroupOrder,
+            Atomosgear,
+            ConditionalJump,
+            Empty,
+
+            MidiMusic = 128
+        }
+
+        [Flags]
+        public enum SoundAttribute
+        {
+            Loop = 0x0001,
+            Reverb = 0x0002,
+            FixedVolume = 0x0004,
+            FixedPosition = 0x0008,
+
+            Music = 0x0020,
+            BypassPLIIz = 0x0040,
+            UseExternalAttr = 0x0080,
+            ExistRoutingSetting = 0x0100,
+            MusicSurround = 0x0200,
+            BusDucking = 0x0400,
+            Acceleration = 0x0800,
+            DynamixEnd = 0x1000,
+            ExtraDesc = 0x2000,
+            DynamixPlus = 0x4000,
+            Atomosgear = 0x8000,
+        }
+
+        public enum FilterType
+        {
+            Bypass,
+            LowPass,
+            HighPass,
+            BandPass,
+            BandEliminate,
+            LowShelving,
+            HighShelving,
+            Peaking
+        }
+
+        public enum InsertEffectName : byte
+        {
+            NoEffect,
+            LowPassFilter,
+            HighPassFilter,
+            BandPassFilter,
+            BandEliminateFilter,
+            LowShelvingFilter,
+            HighShelvingFilter,
+            PeakingFilter,
+            Equalizer,
+            Compressor,
+            Reverb,
+            GranularSynthesizer,
+            Delay,
+            SimpleMeter
+        }
+
+        public struct SoundBasicDesc
+        {
+            public byte TrackCount;
+            public byte BusNumber;
+            public byte Priority;
+            public SoundType Type;
+            public SoundAttribute Attribute;
+            public float Volume;
+            public ushort LocalNumber;
+            public byte UserId;
+            public sbyte PlayHistory;
+        }
+
+        public unsafe struct RoutingInfo
+        {
+            public uint DataSize;
+            public byte SendCount;
+            private fixed byte _reserves[11];
+        }
+
+        public unsafe struct SendInfo
+        {
+            public byte Target;
+            private fixed byte _reserves[3];
+            public float Volume;
+            private fixed uint _reserves2[2];
+        }
+
+        public struct EqualizerFilterParam
+        {
+            public float Freq;
+            public float Invq;
+            public float Gain;
+            public FilterType Type;
+        }
+
+        public struct SoundEqualizerEffect
+        {
+            public EqualizerFilterParam[] Filters;
+            public int NumFilters;
+            private int[] _reserves;
+
+            public SoundEqualizerEffect( LuminaBinaryReader binaryReader )
+            {
+                Filters = binaryReader.ReadStructuresAsArray< EqualizerFilterParam >( 8 );
+                NumFilters = binaryReader.ReadInt32();
+                _reserves = binaryReader.ReadInt32Array( 2 );
+            }
+        }
+
+        public struct SoundEffectParam
+        {
+            public InsertEffectName Type;
+            public byte[] reserves;
+            public SoundEqualizerEffect Param;
+
+            public SoundEffectParam( LuminaBinaryReader binaryReader )
+            {
+                Type = (InsertEffectName)binaryReader.ReadByte();
+                reserves = binaryReader.ReadBytes( 3 );
+                Param = new SoundEqualizerEffect( binaryReader );
+            }
+        }
+
+        public unsafe struct BusDuckingInfo
+        {
+            public byte Size;
+            public byte Number;
+            private fixed byte _reserves[2];
+            public uint FadeTime;
+            public float Volume;
+            private uint _reserve2;
+        }
+
+        public unsafe struct AccelerationData
+        {
+            public byte Version;
+            public byte StructSize;
+            private fixed byte _reserved[2];
+            public float Volume;
+            public int UpTime;
+            public int DownTime;
+        }
+
+        public struct AccelerationInfo
+        {
+            public byte Version;
+            public byte StructSize;
+            public byte NumAcceleration;
+            private byte _reserve;
+            private uint[] _reserve2;
+            public AccelerationData[] Acceleration;
+
+            public AccelerationInfo( LuminaBinaryReader binaryReader )
+            {
+                Version = binaryReader.ReadByte();
+                StructSize = binaryReader.ReadByte();
+                NumAcceleration = binaryReader.ReadByte();
+                _reserve = binaryReader.ReadByte();
+                _reserve2 = binaryReader.ReadUInt32Array( 3 );
+                Acceleration = binaryReader.ReadStructuresAsArray< AccelerationData >( 4 );
+            }
+        }
+
+        public unsafe struct SoundExtraDesc
+        {
+            public byte Version;
+            private byte _reserved;
+            public ushort Size;
+            public uint PlayTimeLength;
+            private fixed uint _reserved2[2];
+        }
+
+        public unsafe struct AtomosgearInfo
+        {
+            public byte Version;
+            private byte _reserved;
+            public ushort Size;
+            public ushort MinNumPeoples;
+            public ushort MaxNumPeoples;
+            private fixed uint _reserved2[2];
+        }
+
+        public struct TrackInfo
+        {
+            public ushort TrackDataIndex;
+            public ushort AudioDataIndex;
+        }
+
+        public struct RandomTrackInfo
+        {
+            public TrackInfo BaseInfo;
+            public uint UpperLimit;
+        }
+
+        public struct CycleInfo
+        {
+            public uint Interval;
+            public ushort NumPlayTrack;
+            public ushort Range;
+        }
+    }
+}

--- a/src/Lumina/Data/Parsing/Scd/ScdSound.cs
+++ b/src/Lumina/Data/Parsing/Scd/ScdSound.cs
@@ -5,221 +5,218 @@ using System;
 
 namespace Lumina.Data.Parsing.Scd
 {
-    public static class ScdSound
+    public enum SoundType : byte
     {
-        public enum SoundType : byte
+        Normal = 1,
+        Random,
+        Stereo,
+        Cycle,
+        Order,
+        FourChannelSurround,
+        Engine,
+        Dialog,
+
+        FixedPosition = 10,
+        DynamixStream,
+        GroupRandom,
+        GroupOrder,
+        Atomosgear,
+        ConditionalJump,
+        Empty,
+
+        MidiMusic = 128
+    }
+
+    [Flags]
+    public enum SoundAttribute
+    {
+        Loop = 0x0001,
+        Reverb = 0x0002,
+        FixedVolume = 0x0004,
+        FixedPosition = 0x0008,
+
+        Music = 0x0020,
+        BypassPLIIz = 0x0040,
+        UseExternalAttr = 0x0080,
+        ExistRoutingSetting = 0x0100,
+        MusicSurround = 0x0200,
+        BusDucking = 0x0400,
+        Acceleration = 0x0800,
+        DynamixEnd = 0x1000,
+        ExtraDesc = 0x2000,
+        DynamixPlus = 0x4000,
+        Atomosgear = 0x8000,
+    }
+
+    public enum FilterType
+    {
+        Bypass,
+        LowPass,
+        HighPass,
+        BandPass,
+        BandEliminate,
+        LowShelving,
+        HighShelving,
+        Peaking
+    }
+
+    public enum InsertEffectName : byte
+    {
+        NoEffect,
+        LowPassFilter,
+        HighPassFilter,
+        BandPassFilter,
+        BandEliminateFilter,
+        LowShelvingFilter,
+        HighShelvingFilter,
+        PeakingFilter,
+        Equalizer,
+        Compressor,
+        Reverb,
+        GranularSynthesizer,
+        Delay,
+        SimpleMeter
+    }
+
+    public struct SoundBasicDesc
+    {
+        public byte TrackCount;
+        public byte BusNumber;
+        public byte Priority;
+        public SoundType Type;
+        public SoundAttribute Attribute;
+        public float Volume;
+        public ushort LocalNumber;
+        public byte UserId;
+        public sbyte PlayHistory;
+    }
+
+    public unsafe struct RoutingInfo
+    {
+        public uint DataSize;
+        public byte SendCount;
+        private fixed byte _reserves[11];
+    }
+
+    public unsafe struct SendInfo
+    {
+        public byte Target;
+        private fixed byte _reserves[3];
+        public float Volume;
+        private fixed uint _reserves2[2];
+    }
+
+    public struct EqualizerFilterParam
+    {
+        public float Freq;
+        public float Invq;
+        public float Gain;
+        public FilterType Type;
+    }
+
+    public struct SoundEqualizerEffect
+    {
+        public EqualizerFilterParam[] Filters;
+        public int NumFilters;
+        private int[] _reserves;
+
+        public SoundEqualizerEffect( LuminaBinaryReader binaryReader )
         {
-            Normal = 1,
-            Random,
-            Stereo,
-            Cycle,
-            Order,
-            FourChannelSurround,
-            Engine,
-            Dialog,
-
-            FixedPosition = 10,
-            DynamixStream,
-            GroupRandom,
-            GroupOrder,
-            Atomosgear,
-            ConditionalJump,
-            Empty,
-
-            MidiMusic = 128
+            Filters = binaryReader.ReadStructuresAsArray< EqualizerFilterParam >( 8 );
+            NumFilters = binaryReader.ReadInt32();
+            _reserves = binaryReader.ReadInt32Array( 2 );
         }
+    }
 
-        [Flags]
-        public enum SoundAttribute
+    public struct SoundEffectParam
+    {
+        public InsertEffectName Type;
+        public byte[] reserves;
+        public SoundEqualizerEffect Param;
+
+        public SoundEffectParam( LuminaBinaryReader binaryReader )
         {
-            Loop = 0x0001,
-            Reverb = 0x0002,
-            FixedVolume = 0x0004,
-            FixedPosition = 0x0008,
-
-            Music = 0x0020,
-            BypassPLIIz = 0x0040,
-            UseExternalAttr = 0x0080,
-            ExistRoutingSetting = 0x0100,
-            MusicSurround = 0x0200,
-            BusDucking = 0x0400,
-            Acceleration = 0x0800,
-            DynamixEnd = 0x1000,
-            ExtraDesc = 0x2000,
-            DynamixPlus = 0x4000,
-            Atomosgear = 0x8000,
+            Type = (InsertEffectName)binaryReader.ReadByte();
+            reserves = binaryReader.ReadBytes( 3 );
+            Param = new SoundEqualizerEffect( binaryReader );
         }
+    }
 
-        public enum FilterType
+    public unsafe struct BusDuckingInfo
+    {
+        public byte Size;
+        public byte Number;
+        private fixed byte _reserves[2];
+        public uint FadeTime;
+        public float Volume;
+        private uint _reserve2;
+    }
+
+    public unsafe struct AccelerationData
+    {
+        public byte Version;
+        public byte StructSize;
+        private fixed byte _reserved[2];
+        public float Volume;
+        public int UpTime;
+        public int DownTime;
+    }
+
+    public struct AccelerationInfo
+    {
+        public byte Version;
+        public byte StructSize;
+        public byte NumAcceleration;
+        private byte _reserve;
+        private uint[] _reserve2;
+        public AccelerationData[] Acceleration;
+
+        public AccelerationInfo( LuminaBinaryReader binaryReader )
         {
-            Bypass,
-            LowPass,
-            HighPass,
-            BandPass,
-            BandEliminate,
-            LowShelving,
-            HighShelving,
-            Peaking
+            Version = binaryReader.ReadByte();
+            StructSize = binaryReader.ReadByte();
+            NumAcceleration = binaryReader.ReadByte();
+            _reserve = binaryReader.ReadByte();
+            _reserve2 = binaryReader.ReadUInt32Array( 3 );
+            Acceleration = binaryReader.ReadStructuresAsArray< AccelerationData >( 4 );
         }
+    }
 
-        public enum InsertEffectName : byte
-        {
-            NoEffect,
-            LowPassFilter,
-            HighPassFilter,
-            BandPassFilter,
-            BandEliminateFilter,
-            LowShelvingFilter,
-            HighShelvingFilter,
-            PeakingFilter,
-            Equalizer,
-            Compressor,
-            Reverb,
-            GranularSynthesizer,
-            Delay,
-            SimpleMeter
-        }
+    public unsafe struct SoundExtraDesc
+    {
+        public byte Version;
+        private byte _reserved;
+        public ushort Size;
+        public uint PlayTimeLength;
+        private fixed uint _reserved2[2];
+    }
 
-        public struct SoundBasicDesc
-        {
-            public byte TrackCount;
-            public byte BusNumber;
-            public byte Priority;
-            public SoundType Type;
-            public SoundAttribute Attribute;
-            public float Volume;
-            public ushort LocalNumber;
-            public byte UserId;
-            public sbyte PlayHistory;
-        }
+    public unsafe struct AtomosgearInfo
+    {
+        public byte Version;
+        private byte _reserved;
+        public ushort Size;
+        public ushort MinNumPeoples;
+        public ushort MaxNumPeoples;
+        private fixed uint _reserved2[2];
+    }
 
-        public unsafe struct RoutingInfo
-        {
-            public uint DataSize;
-            public byte SendCount;
-            private fixed byte _reserves[11];
-        }
+    public struct TrackInfo
+    {
+        public ushort TrackDataIndex;
+        public ushort AudioDataIndex;
+    }
 
-        public unsafe struct SendInfo
-        {
-            public byte Target;
-            private fixed byte _reserves[3];
-            public float Volume;
-            private fixed uint _reserves2[2];
-        }
+    public struct RandomTrackInfo
+    {
+        public TrackInfo BaseInfo;
+        public uint UpperLimit;
+    }
 
-        public struct EqualizerFilterParam
-        {
-            public float Freq;
-            public float Invq;
-            public float Gain;
-            public FilterType Type;
-        }
-
-        public struct SoundEqualizerEffect
-        {
-            public EqualizerFilterParam[] Filters;
-            public int NumFilters;
-            private int[] _reserves;
-
-            public SoundEqualizerEffect( LuminaBinaryReader binaryReader )
-            {
-                Filters = binaryReader.ReadStructuresAsArray< EqualizerFilterParam >( 8 );
-                NumFilters = binaryReader.ReadInt32();
-                _reserves = binaryReader.ReadInt32Array( 2 );
-            }
-        }
-
-        public struct SoundEffectParam
-        {
-            public InsertEffectName Type;
-            public byte[] reserves;
-            public SoundEqualizerEffect Param;
-
-            public SoundEffectParam( LuminaBinaryReader binaryReader )
-            {
-                Type = (InsertEffectName)binaryReader.ReadByte();
-                reserves = binaryReader.ReadBytes( 3 );
-                Param = new SoundEqualizerEffect( binaryReader );
-            }
-        }
-
-        public unsafe struct BusDuckingInfo
-        {
-            public byte Size;
-            public byte Number;
-            private fixed byte _reserves[2];
-            public uint FadeTime;
-            public float Volume;
-            private uint _reserve2;
-        }
-
-        public unsafe struct AccelerationData
-        {
-            public byte Version;
-            public byte StructSize;
-            private fixed byte _reserved[2];
-            public float Volume;
-            public int UpTime;
-            public int DownTime;
-        }
-
-        public struct AccelerationInfo
-        {
-            public byte Version;
-            public byte StructSize;
-            public byte NumAcceleration;
-            private byte _reserve;
-            private uint[] _reserve2;
-            public AccelerationData[] Acceleration;
-
-            public AccelerationInfo( LuminaBinaryReader binaryReader )
-            {
-                Version = binaryReader.ReadByte();
-                StructSize = binaryReader.ReadByte();
-                NumAcceleration = binaryReader.ReadByte();
-                _reserve = binaryReader.ReadByte();
-                _reserve2 = binaryReader.ReadUInt32Array( 3 );
-                Acceleration = binaryReader.ReadStructuresAsArray< AccelerationData >( 4 );
-            }
-        }
-
-        public unsafe struct SoundExtraDesc
-        {
-            public byte Version;
-            private byte _reserved;
-            public ushort Size;
-            public uint PlayTimeLength;
-            private fixed uint _reserved2[2];
-        }
-
-        public unsafe struct AtomosgearInfo
-        {
-            public byte Version;
-            private byte _reserved;
-            public ushort Size;
-            public ushort MinNumPeoples;
-            public ushort MaxNumPeoples;
-            private fixed uint _reserved2[2];
-        }
-
-        public struct TrackInfo
-        {
-            public ushort TrackDataIndex;
-            public ushort AudioDataIndex;
-        }
-
-        public struct RandomTrackInfo
-        {
-            public TrackInfo BaseInfo;
-            public uint UpperLimit;
-        }
-
-        public struct CycleInfo
-        {
-            public uint Interval;
-            public ushort NumPlayTrack;
-            public ushort Range;
-        }
+    public struct CycleInfo
+    {
+        public uint Interval;
+        public ushort NumPlayTrack;
+        public ushort Range;
     }
 }

--- a/src/Lumina/Data/Parsing/Scd/ScdTrack.cs
+++ b/src/Lumina/Data/Parsing/Scd/ScdTrack.cs
@@ -5,236 +5,233 @@ using System;
 
 namespace Lumina.Data.Parsing.Scd
 {
-    public static class ScdTrack
+    public enum TrackCmd : ushort
     {
-        public enum TrackCmd : ushort
-        {
-            End,
-            Volume,
-            Pitch,
-            Interval,
-            Modulation,
-            ReleaseRate,
-            Panning,
-            KeyOn,
-            RandomVolume,
-            RandomPitch,
-            RandomPan,
+        End,
+        Volume,
+        Pitch,
+        Interval,
+        Modulation,
+        ReleaseRate,
+        Panning,
+        KeyOn,
+        RandomVolume,
+        RandomPitch,
+        RandomPan,
 
-            KeyOff = 0xC,
-            LoopStart,
-            LoopEnd,
-            ExternalAudio,
-            EndForLoop,
-            AddInterval,
-            Expression,
-            Velocity,
-            MidiVolume,
-            MidiAddVolume,
-            MidiPan,
-            MidiAddPan,
-            ModulationType,
-            ModulationDepth,
-            ModulationAddDepth,
-            ModulationSpeed,
-            ModulationAddSpeed,
-            ModulationOff,
-            PitchBend,
-            Transpose,
-            AddTranspose,
-            FrPanning,
-            RandomWait,
-            Adsr,
-            CutOff,
-            Jump,
-            PlayContinueLoop,
-            Sweep,
-            MidiKeyOnOld,
-            SlurOn,
-            SlurOff,
-            AutoAdsrEnvelope,
-            MidiExternalAudio,
-            Marker,
-            InitParams,
-            Version,
-            ReverbOn,
-            ReverbOff,
-            MidiKeyOn,
-            PortamentoOn,
-            PortamentoOff,
-            MidiEnd,
-            ClearKeyInfo,
-            ModulationDepthFade,
-            ModulationSpeedFade,
-            AnalysisFlag,
-            Config,
-            Filter,
-            PlayInnerSound,
-            VolumeZeroOne,
-            ZeroOneJump,
-            ChannelVolumeZeroOne,
-            Unknown64
-        }
-
-        public enum TrackCmdJump : byte
-        {
-            LZE = 0x1,
-            LNZ,
-        }
-
-        public enum TrackCmdConfigType : ushort
-        {
-            NOP,
-            IntervalType,
-            IntervalTypeFloat = 1
-        }
-
-        public enum OscillatorCarrier : byte
-        {
-            None,
-            Volume,
-            Pitch,
-            Pan,
-            FrPan
-        }
-
-        public enum OscillatorMode : byte
-        {
-            None,
-            Sine,
-            Rectangle,
-            Triangle,
-            Saw,
-            Random,
-            ReverseSine,
-            ReverseRectangle,
-            ReverseTriangle,
-            ReverseSaw
-        }
-
-        public enum VolumeCurveType : byte
-        {
-            Auto,
-            Square,
-            White,
-            Old,
-            OldWiiEmu,
-            WhiteOnlyMusic,
-            Caelum
-        }
-
-        public struct TrackCmdParam
-        {
-            public float Value;
-            public uint Time;
-        }
-
-        public struct ModulationCmdParam
-        {
-            public OscillatorCarrier Carrier;
-            public OscillatorMode Modulator;
-            public VolumeCurveType Curve;
-            private byte _reserve;
-            public float Depth;
-            public uint Rate;
-        }
-
-        public struct RandomCmdParam
-        {
-            public float Upper;
-            public float Lower;
-        }
-
-        public struct ExternalAudioInfo
-        {
-            public ushort BankNumber;
-            public short Index;
-            public short[] RandomIndices;
-
-            public ExternalAudioInfo( LuminaBinaryReader binaryReader )
-            {
-                BankNumber = binaryReader.ReadUInt16();
-                Index = binaryReader.ReadInt16();
-                RandomIndices = Index < 0 ? binaryReader.ReadInt16Array( -Index ) : Array.Empty< short >();
-            }
-        }
-
-        public struct TrackChannelZeroOneParamHeader
-        {
-            public sbyte Version;
-            public sbyte Reserved;
-            public short HeaderSize;
-            public short NumChannels;
-        }
-
-        public struct TrackZeroOneParamHeader
-        {
-            public sbyte Version;
-            public sbyte Reserved;
-            public short HeaderSize;
-            public short NumPoints;
-        }
-
-        public struct TrackZeroOnePoint
-        {
-            public ushort ZeroOne;
-            public ushort Value;
-        }
-
-        #region Track helper structs
-
-        public struct ModulationDepth
-        {
-            public uint Carrier;
-            public float Depth;
-            public int FadeTime;
-        }
-
-        public struct ModulationSpeed
-        {
-            public uint Carrier;
-            public uint Speed;
-            public int FadeTime;
-        }
-
-        public struct AutoAdsrEnvelope
-        {
-            public uint AttackTime;
-            public uint DecayTime;
-            public float SustainLevel;
-            public uint ReleaseTime;
-        }
-
-        public struct TrackFilter
-        {
-            public ScdSound.FilterType Type;
-            public float Frequency;
-            public float InvQ;
-            public float Gain;
-        }
-
-        public struct TrackConfig
-        {
-            public TrackCmdConfigType Type;
-            public ushort Count;
-            public object Data;
-        }
-
-        public struct TrackUnknown64Header
-        {
-            public sbyte Version;
-            public sbyte Count;
-            public ushort Unknown;
-        }
-
-        public unsafe struct TrackUnknown64
-        {
-            public ushort BankNumber;
-            public ushort Index;
-            public fixed byte Unknown[4];
-            public float UnknownFloat;
-        }
-
-        #endregion
+        KeyOff = 0xC,
+        LoopStart,
+        LoopEnd,
+        ExternalAudio,
+        EndForLoop,
+        AddInterval,
+        Expression,
+        Velocity,
+        MidiVolume,
+        MidiAddVolume,
+        MidiPan,
+        MidiAddPan,
+        ModulationType,
+        ModulationDepth,
+        ModulationAddDepth,
+        ModulationSpeed,
+        ModulationAddSpeed,
+        ModulationOff,
+        PitchBend,
+        Transpose,
+        AddTranspose,
+        FrPanning,
+        RandomWait,
+        Adsr,
+        CutOff,
+        Jump,
+        PlayContinueLoop,
+        Sweep,
+        MidiKeyOnOld,
+        SlurOn,
+        SlurOff,
+        AutoAdsrEnvelope,
+        MidiExternalAudio,
+        Marker,
+        InitParams,
+        Version,
+        ReverbOn,
+        ReverbOff,
+        MidiKeyOn,
+        PortamentoOn,
+        PortamentoOff,
+        MidiEnd,
+        ClearKeyInfo,
+        ModulationDepthFade,
+        ModulationSpeedFade,
+        AnalysisFlag,
+        Config,
+        Filter,
+        PlayInnerSound,
+        VolumeZeroOne,
+        ZeroOneJump,
+        ChannelVolumeZeroOne,
+        Unknown64
     }
+
+    public enum TrackCmdJump : byte
+    {
+        LZE = 0x1,
+        LNZ,
+    }
+
+    public enum TrackCmdConfigType : ushort
+    {
+        NOP,
+        IntervalType,
+        IntervalTypeFloat = 1
+    }
+
+    public enum OscillatorCarrier : byte
+    {
+        None,
+        Volume,
+        Pitch,
+        Pan,
+        FrPan
+    }
+
+    public enum OscillatorMode : byte
+    {
+        None,
+        Sine,
+        Rectangle,
+        Triangle,
+        Saw,
+        Random,
+        ReverseSine,
+        ReverseRectangle,
+        ReverseTriangle,
+        ReverseSaw
+    }
+
+    public enum VolumeCurveType : byte
+    {
+        Auto,
+        Square,
+        White,
+        Old,
+        OldWiiEmu,
+        WhiteOnlyMusic,
+        Caelum
+    }
+
+    public struct TrackCmdParam
+    {
+        public float Value;
+        public uint Time;
+    }
+
+    public struct ModulationCmdParam
+    {
+        public OscillatorCarrier Carrier;
+        public OscillatorMode Modulator;
+        public VolumeCurveType Curve;
+        private byte _reserve;
+        public float Depth;
+        public uint Rate;
+    }
+
+    public struct RandomCmdParam
+    {
+        public float Upper;
+        public float Lower;
+    }
+
+    public struct ExternalAudioInfo
+    {
+        public ushort BankNumber;
+        public short Index;
+        public short[] RandomIndices;
+
+        public ExternalAudioInfo( LuminaBinaryReader binaryReader )
+        {
+            BankNumber = binaryReader.ReadUInt16();
+            Index = binaryReader.ReadInt16();
+            RandomIndices = Index < 0 ? binaryReader.ReadInt16Array( -Index ) : Array.Empty< short >();
+        }
+    }
+
+    public struct TrackChannelZeroOneParamHeader
+    {
+        public sbyte Version;
+        public sbyte Reserved;
+        public short HeaderSize;
+        public short NumChannels;
+    }
+
+    public struct TrackZeroOneParamHeader
+    {
+        public sbyte Version;
+        public sbyte Reserved;
+        public short HeaderSize;
+        public short NumPoints;
+    }
+
+    public struct TrackZeroOnePoint
+    {
+        public ushort ZeroOne;
+        public ushort Value;
+    }
+
+    #region Track helper structs
+
+    public struct ModulationDepth
+    {
+        public uint Carrier;
+        public float Depth;
+        public int FadeTime;
+    }
+
+    public struct ModulationSpeed
+    {
+        public uint Carrier;
+        public uint Speed;
+        public int FadeTime;
+    }
+
+    public struct AutoAdsrEnvelope
+    {
+        public uint AttackTime;
+        public uint DecayTime;
+        public float SustainLevel;
+        public uint ReleaseTime;
+    }
+
+    public struct TrackFilter
+    {
+        public FilterType Type;
+        public float Frequency;
+        public float InvQ;
+        public float Gain;
+    }
+
+    public struct TrackConfig
+    {
+        public TrackCmdConfigType Type;
+        public ushort Count;
+        public object Data;
+    }
+
+    public struct TrackUnknown64Header
+    {
+        public sbyte Version;
+        public sbyte Count;
+        public ushort Unknown;
+    }
+
+    public unsafe struct TrackUnknown64
+    {
+        public ushort BankNumber;
+        public ushort Index;
+        public fixed byte Unknown[4];
+        public float UnknownFloat;
+    }
+
+    #endregion
 }

--- a/src/Lumina/Data/Parsing/Scd/ScdTrack.cs
+++ b/src/Lumina/Data/Parsing/Scd/ScdTrack.cs
@@ -1,0 +1,240 @@
+using System;
+
+#pragma warning disable CS0169
+#pragma warning disable CS1591
+
+namespace Lumina.Data.Parsing.Scd
+{
+    public static class ScdTrack
+    {
+        public enum TrackCmd : ushort
+        {
+            End,
+            Volume,
+            Pitch,
+            Interval,
+            Modulation,
+            ReleaseRate,
+            Panning,
+            KeyOn,
+            RandomVolume,
+            RandomPitch,
+            RandomPan,
+
+            KeyOff = 0xC,
+            LoopStart,
+            LoopEnd,
+            ExternalAudio,
+            EndForLoop,
+            AddInterval,
+            Expression,
+            Velocity,
+            MidiVolume,
+            MidiAddVolume,
+            MidiPan,
+            MidiAddPan,
+            ModulationType,
+            ModulationDepth,
+            ModulationAddDepth,
+            ModulationSpeed,
+            ModulationAddSpeed,
+            ModulationOff,
+            PitchBend,
+            Transpose,
+            AddTranspose,
+            FrPanning,
+            RandomWait,
+            Adsr,
+            CutOff,
+            Jump,
+            PlayContinueLoop,
+            Sweep,
+            MidiKeyOnOld,
+            SlurOn,
+            SlurOff,
+            AutoAdsrEnvelope,
+            MidiExternalAudio,
+            Marker,
+            InitParams,
+            Version,
+            ReverbOn,
+            ReverbOff,
+            MidiKeyOn,
+            PortamentoOn,
+            PortamentoOff,
+            MidiEnd,
+            ClearKeyInfo,
+            ModulationDepthFade,
+            ModulationSpeedFade,
+            AnalysisFlag,
+            Config,
+            Filter,
+            PlayInnerSound,
+            VolumeZeroOne,
+            ZeroOneJump,
+            ChannelVolumeZeroOne,
+            Unknown64
+        }
+
+        public enum TrackCmdJump : byte
+        {
+            LZE = 0x1,
+            LNZ,
+        }
+
+        public enum TrackCmdConfigType : ushort
+        {
+            NOP,
+            IntervalType,
+            IntervalTypeFloat = 1
+        }
+
+        public enum OscillatorCarrier : byte
+        {
+            None,
+            Volume,
+            Pitch,
+            Pan,
+            FrPan
+        }
+
+        public enum OscillatorMode : byte
+        {
+            None,
+            Sine,
+            Rectangle,
+            Triangle,
+            Saw,
+            Random,
+            ReverseSine,
+            ReverseRectangle,
+            ReverseTriangle,
+            ReverseSaw
+        }
+
+        public enum VolumeCurveType : byte
+        {
+            Auto,
+            Square,
+            White,
+            Old,
+            OldWiiEmu,
+            WhiteOnlyMusic,
+            Caelum
+        }
+
+        public struct TrackCmdParam
+        {
+            public float Value;
+            public uint Time;
+        }
+
+        public struct ModulationCmdParam
+        {
+            public OscillatorCarrier Carrier;
+            public OscillatorMode Modulator;
+            public VolumeCurveType Curve;
+            private byte _reserve;
+            public float Depth;
+            public uint Rate;
+        }
+
+        public struct RandomCmdParam
+        {
+            public float Upper;
+            public float Lower;
+        }
+
+        public struct ExternalAudioInfo
+        {
+            public ushort BankNumber;
+            public short Index;
+            public short[] RandomIndices;
+
+            public ExternalAudioInfo( LuminaBinaryReader binaryReader )
+            {
+                BankNumber = binaryReader.ReadUInt16();
+                Index = binaryReader.ReadInt16();
+                RandomIndices = Index < 0 ? binaryReader.ReadInt16Array( -Index ) : Array.Empty< short >();
+            }
+        }
+
+        public struct TrackChannelZeroOneParamHeader
+        {
+            public sbyte Version;
+            public sbyte Reserved;
+            public short HeaderSize;
+            public short NumChannels;
+        }
+
+        public struct TrackZeroOneParamHeader
+        {
+            public sbyte Version;
+            public sbyte Reserved;
+            public short HeaderSize;
+            public short NumPoints;
+        }
+
+        public struct TrackZeroOnePoint
+        {
+            public ushort ZeroOne;
+            public ushort Value;
+        }
+
+        #region Track helper structs
+
+        public struct ModulationDepth
+        {
+            public uint Carrier;
+            public float Depth;
+            public int FadeTime;
+        }
+
+        public struct ModulationSpeed
+        {
+            public uint Carrier;
+            public uint Speed;
+            public int FadeTime;
+        }
+
+        public struct AutoAdsrEnvelope
+        {
+            public uint AttackTime;
+            public uint DecayTime;
+            public float SustainLevel;
+            public uint ReleaseTime;
+        }
+
+        public struct TrackFilter
+        {
+            public ScdSound.FilterType Type;
+            public float Frequency;
+            public float InvQ;
+            public float Gain;
+        }
+
+        public struct TrackConfig
+        {
+            public TrackCmdConfigType Type;
+            public ushort Count;
+            public object Data;
+        }
+
+        public struct TrackUnknown64Header
+        {
+            public sbyte Version;
+            public sbyte Count;
+            public ushort Unknown;
+        }
+
+        public unsafe struct TrackUnknown64
+        {
+            public ushort BankNumber;
+            public ushort Index;
+            public fixed byte Unknown[4];
+            public float UnknownFloat;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
This adds support to read the following sections in a scd file:

- Sound
- Track (prototype parsing)
- Audio
- Layout
- Attribute

The "Routing" section isn't currently being read as I couldn't find a parsing method for that in the game executable nor a scd file using this section in the game files.