### PR TITLE
Use lowercase name in RemoveSheetFromCache

### DIFF
--- a/src/Lumina/Excel/ExcelModule.cs
+++ b/src/Lumina/Excel/ExcelModule.cs
@@ -171,10 +171,11 @@ namespace Lumina.Excel
         public void RemoveSheetFromCache< T >( string name ) where T : ExcelRow
         {
             var tid = BuildTypeIdentifier( typeof( T ) );
+            var lowerName = name.ToLowerInvariant();
             
             foreach( Language language in Enum.GetValues( typeof( Language ) ) )
             {
-                var id = Tuple.Create( language, name, tid );
+                var id = Tuple.Create( language, lowerName, tid );
 
                 _sheetCache.Remove( id );
             }


### PR DESCRIPTION
RemoveSheetFromCache when called with no parameters will generate the name based off the sheet's name property. 
This is generally uppercase, GetSheet handles this by calling ToLowerInvariant on the name which is then passed to the ID tuple.
This change does the same for RemoveSheetFromCache.