### PR TITLE
Add SeString ToString overrides

### DIFF
--- a/src/Lumina/Text/Expressions/BinaryExpression.cs
+++ b/src/Lumina/Text/Expressions/BinaryExpression.cs
@@ -41,12 +41,12 @@ public class BinaryExpression : BaseExpression
     {
         return ExpressionType switch
         {
-            ExpressionType.GreaterThanOrEqualTo => $"BinExpr{{{Operand1} >= {Operand2}}}",
-            ExpressionType.GreaterThan => $"BinExpr{{{Operand1} > {Operand2}}}",
-            ExpressionType.LessThanOrEqualTo => $"BinExpr{{{Operand1} <= {Operand2}}}",
-            ExpressionType.LessThan => $"BinExpr{{{Operand1} < {Operand2}}}",
-            ExpressionType.Equal => $"BinExpr{{{Operand1} == {Operand2}}}",
-            ExpressionType.NotEqual => $"BinExpr{{{Operand1} != {Operand2}}}",
+            ExpressionType.GreaterThanOrEqualTo => $"[{Operand1}>={Operand2}]",
+            ExpressionType.GreaterThan => $"[{Operand1}>{Operand2}]",
+            ExpressionType.LessThanOrEqualTo => $"[{Operand1}<={Operand2}]",
+            ExpressionType.LessThan => $"[{Operand1}<{Operand2}]",
+            ExpressionType.Equal => $"[{Operand1}=={Operand2}]",
+            ExpressionType.NotEqual => $"[{Operand1}!={Operand2}]",
             _ => throw new NotImplementedException() // cannot reach, as this instance is immutable and this field is filtered from constructor
         };
     }

--- a/src/Lumina/Text/Expressions/ExpressionType.cs
+++ b/src/Lumina/Text/Expressions/ExpressionType.cs
@@ -2,25 +2,32 @@ namespace Lumina.Text.Expressions;
 
 public enum ExpressionType : byte
 {
-    // Placeholder expressions (Zero arity): 0xD0 ~ 0xDF
-    Hour = 0xDB,  // 0 ~ 23
-    Weekday = 0xDD,  // 1(sunday) ~ 7(saturday)
+    // Placeholder expressions (Zero arity): 0xD8 ~ 0xDF
+    Millisecond = 0xD8, // t_msec
+    Second = 0xD9, // t_sec
+    Minute = 0xDA, // t_min
+    Hour = 0xDB,  // t_hour 0 ~ 23
+    Day = 0xDC, // t_day
+    Weekday = 0xDD,  // t_wday 1(sunday) ~ 7(saturday)
+    Month = 0xDE, // t_mon
+    Year = 0xDF, // t_year
 
     // Binary expressions
-    GreaterThanOrEqualTo = 0xE0,
-    GreaterThan = 0xE1,
-    LessThanOrEqualTo = 0xE2,
-    LessThan = 0xE3,
-    Equal = 0xE4,
-    NotEqual = 0xE5,
+    GreaterThanOrEqualTo = 0xE0, // [gteq]
+    GreaterThan = 0xE1, // [gt]
+    LessThanOrEqualTo = 0xE2, // [lteq]
+    LessThan = 0xE3, // [lt]
+    Equal = 0xE4, // [eq]
+    NotEqual = 0xE5, // [neq]
 
     // Parameter (unary expressions)
-    IntegerParameter = 0xE8,
-    PlayerParameter = 0xE9,
-    StringParameter = 0xEA,
-    ObjectParameter = 0xEB,
+    IntegerParameter = 0xE8, // lnum
+    PlayerParameter = 0xE9, // gnum
+    StringParameter = 0xEA, // lstr
+    ObjectParameter = 0xEB, // gstr
 
     // Placeholder expressions also exist between 0xEC ~ 0xEF, where 0xEC is at least checked existing.
+    StackColor = 0xEC, // stackcolor
 
     // Embedded SeString
     SeString = 0xff,  // Followed by length (including length) and data

--- a/src/Lumina/Text/Expressions/IntegerExpression.cs
+++ b/src/Lumina/Text/Expressions/IntegerExpression.cs
@@ -92,7 +92,7 @@ public class IntegerExpression : BaseExpression
     }
 
     /// <inheritdoc />
-    public override string ToString() => Value.ToString();
+    public override string ToString() => ( (int)Value ).ToString();
 
     /// <summary>
     /// Parse given Stream into an IntegerExpression.

--- a/src/Lumina/Text/Expressions/ParameterExpression.cs
+++ b/src/Lumina/Text/Expressions/ParameterExpression.cs
@@ -35,10 +35,10 @@ public class ParameterExpression : BaseExpression
     {
         return ExpressionType switch
         {
-            ExpressionType.IntegerParameter => $"IntegerParam{{{Operand}}}",
-            ExpressionType.PlayerParameter => $"PlayerParam{{{Operand}}}",
-            ExpressionType.StringParameter => $"StringParam{{{Operand}}}",
-            ExpressionType.ObjectParameter => $"ObjectParam{{{Operand}}}",
+            ExpressionType.IntegerParameter => $"lnum{Operand}",
+            ExpressionType.PlayerParameter => $"gnum{Operand}",
+            ExpressionType.StringParameter => $"lstr{Operand}",
+            ExpressionType.ObjectParameter => $"gstr{Operand}",
             _ => throw new NotImplementedException() // cannot reach, as this instance is immutable and this field is filtered from constructor
         };
     }

--- a/src/Lumina/Text/Expressions/PlaceholderExpression.cs
+++ b/src/Lumina/Text/Expressions/PlaceholderExpression.cs
@@ -28,7 +28,22 @@ public class PlaceholderExpression : BaseExpression
     public override void Encode( Stream stream ) => stream.WriteByte( (byte)ExpressionType );
 
     /// <inheritdoc />
-    public override string ToString() => $"Placeholder#{ExpressionType:X02}";
+    public override string ToString()
+    {
+        return ExpressionType switch
+        {
+            ExpressionType.Millisecond => "t_msec",
+            ExpressionType.Second => "t_sec",
+            ExpressionType.Minute => "t_min",
+            ExpressionType.Hour => "t_hour",
+            ExpressionType.Day => "t_day",
+            ExpressionType.Weekday => "t_wday",
+            ExpressionType.Month => "t_mon",
+            ExpressionType.Year => "t_year",
+            ExpressionType.StackColor => "stackcolor",
+            _ => $"Placeholder#{ExpressionType:X02}"
+        };
+    }
 
     /// <summary>
     /// Identify whether the given type byte indicates a PlaceholderExpression.

--- a/src/Lumina/Text/Expressions/StringExpression.cs
+++ b/src/Lumina/Text/Expressions/StringExpression.cs
@@ -45,7 +45,7 @@ public class StringExpression : BaseExpression
     }
 
     /// <inheritdoc />
-    public override string ToString() => $"Str{{{Value?.ToString() ?? string.Empty}}}";
+    public override string ToString() => Value?.ToString() ?? string.Empty;
 
     /// <summary>
     /// Parse given Stream into a StringExpression.

--- a/src/Lumina/Text/Payloads/BasePayload.cs
+++ b/src/Lumina/Text/Payloads/BasePayload.cs
@@ -245,7 +245,7 @@ namespace Lumina.Text.Payloads
         public override string ToString()
         {
             if( PayloadType == PayloadType.Text )
-                return RawString;
+                return RawString.Replace( "<", "\\<" );
 
             var code = (MacroCodes)PayloadType;
             switch( code )

--- a/src/Lumina/Text/Payloads/BasePayload.cs
+++ b/src/Lumina/Text/Payloads/BasePayload.cs
@@ -240,5 +240,32 @@ namespace Lumina.Text.Payloads
         /// Extracts and concatenates the text payloads and integer constants.
         /// </summary>
         public string RawString => _rawString.Value;
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            if( PayloadType == PayloadType.Text )
+                return RawString;
+
+            var code = (MacroCodes)PayloadType;
+            switch( code )
+            {
+                case MacroCodes.NewLine:
+                    return "<br>";
+                case MacroCodes.NonBreakingSpace:
+                    return "<nbsp>";
+                case MacroCodes.SoftHyphen:
+                    return "-";
+                case MacroCodes.Hyphen:
+                    return "--";
+                default:
+                {
+                    if( Expressions.Count == 0 )
+                        return $"<{code.ToString().ToLower()}>";
+
+                    return $"<{code.ToString().ToLower()}({string.Join( ',', Expressions )})>";
+                }
+            }
+        }
     }
 }

--- a/src/Lumina/Text/Payloads/MacroCodes.cs
+++ b/src/Lumina/Text/Payloads/MacroCodes.cs
@@ -1,0 +1,59 @@
+namespace Lumina.Text.Payloads;
+
+internal enum MacroCodes : byte
+{
+    SetResetTime = 0x06, // n N x
+    SetTime = 0x07, // n x
+    If = 0x08, // . . * x
+    Switch = 0x09, // . . .
+    PcName = 0x0A, // n x
+    IfPcGender = 0x0B, // n . . x
+    IfPcName = 0x0C, // n . . . x
+    Josa = 0x0D, // s s s x
+    Josaro = 0x0E, // s s s x
+    IfSelf = 0x0F, // n . . x
+    NewLine = 0x10, // <br>
+    Wait = 0x11, // n x
+    Icon = 0x12, // n x
+    Color = 0x13, // n N x
+    EdgeColor = 0x14, // n N x
+    ShadowColor = 0x15, // n N x
+    SoftHyphen = 0x16, // -
+    Key = 0x17, // 
+    Scale = 0x18, // n
+    Bold = 0x19, // n
+    Italic = 0x1A, // n
+    Edge = 0x1B, // n n
+    Shadow = 0x1C, // n n
+    NonBreakingSpace = 0x1D, // <nbsp>
+    Icon2 = 0x1E, // n N x
+    Hyphen = 0x1F, // --
+    Num = 0x20, // n x
+    Hex = 0x21, // n x
+    Kilo = 0x22, // . s x
+    Byte = 0x23, // n x
+    Sec = 0x24, // n x
+    Time = 0x25, // n x
+    Float = 0x26, // n n s x
+    Link = 0x27, // n n n n s
+    Sheet = 0x28, // s . . .
+    String = 0x29, // s x
+    Caps = 0x2A, // s x
+    Head = 0x2B, // s x
+    Split = 0x2C, // s s n x
+    HeadAll = 0x2D, // s x
+    Fixed = 0x2E, // n n . . .
+    Lower = 0x2F, // s x
+    JaNoun = 0x30, // s . .
+    EnNoun = 0x31, // s . .
+    DeNoun = 0x32, // s . .
+    FrNoun = 0x33, // s . .
+    ChNoun = 0x34, // s . .
+    LowerHead = 0x40, // s x
+    ColorType = 0x48, // n x
+    EdgeColorType = 0x49, // n x
+    Digit = 0x50, // n n x
+    Ordinal = 0x51, // n x
+    Sound = 0x60, // n n
+    LevelPos = 0x61 // n x
+}

--- a/src/Lumina/Text/SeString.cs
+++ b/src/Lumina/Text/SeString.cs
@@ -170,7 +170,7 @@ namespace Lumina.Text
 
         public override string ToString()
         {
-            return RawString;
+            return string.Concat( Payloads );
         }
     }
 }


### PR DESCRIPTION
overrides SeStrings ToString() methods on payloads and expressions to output text using the games macrocode syntax.
this is mostly cosmetic/for display purpose as you already get the bytes from the sheets.

example output for `Addon#153` using `SeString.ToString()`:
en
`<colortype(508)><edgecolortype(509)>Discard <ennoun(Item,2,lnum1,1,1)><if([lnum2>0], (Collectability Rating: <num(lnum2)>),)>?<edgecolortype(0)><colortype(0)>`
jp
`<colortype(508)><edgecolortype(509)><if([lnum2>0],収集価値<num(lnum2)>の,)><sheet(Item,lnum1,0)>を捨てます。<br>よろしいですか？<edgecolortype(0)><colortype(0)>`