### PR TITLE
Fix FormatException in PlaceholderExpression

### DIFF
--- a/src/Lumina/Text/Expressions/PlaceholderExpression.cs
+++ b/src/Lumina/Text/Expressions/PlaceholderExpression.cs
@@ -41,7 +41,7 @@ public class PlaceholderExpression : BaseExpression
             ExpressionType.Month => "t_mon",
             ExpressionType.Year => "t_year",
             ExpressionType.StackColor => "stackcolor",
-            _ => $"Placeholder#{ExpressionType:X02}"
+            _ => $"Placeholder#{(byte)ExpressionType:X02}"
         };
     }
 


### PR DESCRIPTION
I ran into a FormatException because the ExpressionType enum value is formatted using X02, which doesn't work.
Casting it to the underlying type (byte) fixes the exception.

See https://dotnetfiddle.net/OfVPzo

Also, I'd like to request a release after this PR. I would like to use the new enum values that pohky added. 🙂
