### PR TITLE
Revert SeString ToString change

### DIFF
--- a/src/Lumina/Text/SeString.cs
+++ b/src/Lumina/Text/SeString.cs
@@ -170,6 +170,14 @@ namespace Lumina.Text
 
         public override string ToString()
         {
+            return RawString;
+        }
+
+        /// <summary>
+        /// Gets a Macro Code representation of the Text and Payloads contained.
+        /// </summary>
+        public string ToMacroString()
+        {
             return string.Concat( Payloads );
         }
     }


### PR DESCRIPTION
reverting the output of ToString() back to RawString as the change was causing some confusion and adding a new method instead.

or should this be a property or remove it from SeString to not add to the api unnecessarily?