### PR TITLE
Repurpose MSB of MipLevelsCount

### DIFF
--- a/src/Lumina/Data/Files/TexFile.cs
+++ b/src/Lumina/Data/Files/TexFile.cs
@@ -168,11 +168,6 @@ namespace Lumina.Data.Files
 
             /// <summary>The field has been repurposed; use <see cref="MipCount"/>.</summary>
             [FieldOffset( 14 )]
-            [Obsolete( $"Use {nameof( MipCount )} instead; the field has been repurposed as three fields." )]
-            public ushort MipLevels;
-            
-            /// <summary>The field has been repurposed; use <see cref="MipCount"/>.</summary>
-            [FieldOffset( 14 )]
             [Obsolete( $"Use {nameof( MipCount )} instead; the field has been repurposed as two fields." )]
             public byte MipLevelsCount;
 

--- a/src/Lumina/Data/Parsing/Tex/Buffers/TextureBuffer.cs
+++ b/src/Lumina/Data/Parsing/Tex/Buffers/TextureBuffer.cs
@@ -515,7 +515,7 @@ namespace Lumina.Data.Parsing.Tex.Buffers
         /// </summary>
         public static unsafe TextureBuffer FromStream( TexFile.TexHeader header, LuminaBinaryReader reader )
         {
-            var mipmapAllocations = new int[Math.Min( 13, (int)header.MipLevelsCount )];
+            var mipmapAllocations = new int[Math.Min( 13, header.MipCount )];
             for( var i = 0; i < mipmapAllocations.Length - 1; i++ )
                 mipmapAllocations[ i ] = (int)( header.OffsetToSurface[ i + 1 ] - header.OffsetToSurface[ i ] );
             mipmapAllocations[ ^1 ] = (int)( reader.BaseStream.Length - header.OffsetToSurface[ mipmapAllocations.Length - 1 ] );


### PR DESCRIPTION
DT Bench: `040000/~001b31fa` has `0x8C` as `MipLevelsCount`. According to the function at `+0x224b20`, the code is applying `& 0x7F` to the value, which cannot be found in the retail game version, and checks the MSB of the byte for something.