### PR TITLE
Added option to skip caching when enumerating rows

### DIFF
--- a/src/Lumina/Excel/ExcelSheet.cs
+++ b/src/Lumina/Excel/ExcelSheet.cs
@@ -55,9 +55,12 @@ namespace Lumina.Excel
             {
                 rowObj.PopulateData( parser, GameData, RequestedLanguage );
             }
-
-            _rowCache[ cacheKey ] = rowObj;
-
+            
+            if( !NoCache.IsEnabled )
+            {
+                _rowCache[ cacheKey ] = rowObj;
+            }
+            
             return rowObj;
         }
 
@@ -82,7 +85,7 @@ namespace Lumina.Excel
             return obj;
         }
         
-        public IEnumerator< T > GetEnumerator( bool skipCaching )
+        public IEnumerator< T > GetEnumerator()
         {
             ExcelDataFile file = null!;
             RowParser parser = null!;
@@ -111,7 +114,7 @@ namespace Lumina.Excel
                         }
 
                         var obj = ReadSubRowObj( parser, rowPtr.RowId, i );
-                        if( !skipCaching )
+                        if( !NoCache.IsEnabled )
                         {
                             _rowCache.TryAdd( cacheKey, obj );
                         }
@@ -129,7 +132,7 @@ namespace Lumina.Excel
                     }
                         
                     var obj = ReadRowObj( parser, rowPtr.RowId );
-                    if( !skipCaching )
+                    if( !NoCache.IsEnabled )
                     {
                         _rowCache.TryAdd( cacheKey, obj );
                     }
@@ -139,14 +142,9 @@ namespace Lumina.Excel
             }
         }
         
-        public IEnumerator< T > GetEnumerator()
-        {
-            return GetEnumerator( false );
-        }
-        
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetEnumerator( false );
+            return GetEnumerator();
         }
     }
 }

--- a/src/Lumina/Excel/ExcelSheet.cs
+++ b/src/Lumina/Excel/ExcelSheet.cs
@@ -82,7 +82,7 @@ namespace Lumina.Excel
             return obj;
         }
         
-        public IEnumerator< T > GetEnumerator()
+        public IEnumerator< T > GetEnumerator( bool skipCaching )
         {
             ExcelDataFile file = null!;
             RowParser parser = null!;
@@ -111,7 +111,11 @@ namespace Lumina.Excel
                         }
 
                         var obj = ReadSubRowObj( parser, rowPtr.RowId, i );
-                        _rowCache.TryAdd( cacheKey, obj );
+                        if( !skipCaching )
+                        {
+                            _rowCache.TryAdd( cacheKey, obj );
+                        }
+                        
                         yield return obj;
                     }
                 }
@@ -125,15 +129,24 @@ namespace Lumina.Excel
                     }
                         
                     var obj = ReadRowObj( parser, rowPtr.RowId );
-                    _rowCache.TryAdd( cacheKey, obj );
+                    if( !skipCaching )
+                    {
+                        _rowCache.TryAdd( cacheKey, obj );
+                    }
+                    
                     yield return obj;
                 }
             }
         }
-
+        
+        public IEnumerator< T > GetEnumerator()
+        {
+            return GetEnumerator( false );
+        }
+        
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetEnumerator();
+            return GetEnumerator( false );
         }
     }
 }

--- a/src/Lumina/Excel/NoCache.cs
+++ b/src/Lumina/Excel/NoCache.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Lumina.Excel
+{
+    /// <summary>
+    /// Class that allows to skip the caching of Excel rows when they are read.
+    /// </summary>
+    public sealed class NoCache : IDisposable
+    {
+        [field: ThreadStatic]
+        internal static bool IsEnabled { get; private set; }
+        
+        /// <summary>
+        /// Disables the caching of Excel rows when they are read.
+        /// </summary>
+        public NoCache()
+        {
+            IsEnabled = true;
+        }
+        
+        /// <summary>
+        /// Re-enables the caching of Excel rows when they are read.
+        /// </summary>
+        public void Dispose()
+        {
+            IsEnabled = false;
+        }
+    }
+}


### PR DESCRIPTION
This might be a special request but I have a use case where not adding read rows to the cache would be ideal.
I'm writing a Dalamud plugin that searches for translations of game content and that means that I read a lot of rows from many sheets in order to find an item that matches the search string (ex: ex: "popoto" will match "popoto", "popoto step" and "Popotoes au Gratin")
In a Dalamud context the sheet cache (and the row cache) are always kept in memory and using `ExcelModule.RemoveSheetFromCache<T>()` would be detrimental to other users of the cache.

Therefore it would simply be best for me be able to iterate over rows without loading a gigabyte of data into the cache ^^'

PS. I'm not sure why I had to add another `GetEnumerator` method, but it wouldn't compile without it
