### PR TITLE
Fix `SeStringReadOnlySpan.ToString` and add `SeStringBuilder.AppendMacroString`

### DIFF
--- a/src/Lumina.Tests/Lumina.Tests.csproj
+++ b/src/Lumina.Tests/Lumina.Tests.csproj
@@ -4,6 +4,8 @@
         <TargetFramework>net8.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
+
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Lumina.Tests/SeStringBuilderTests.cs
+++ b/src/Lumina.Tests/SeStringBuilderTests.cs
@@ -431,6 +431,19 @@ public class SeStringBuilderTests
     }
 
     [Fact]
+    public unsafe void InterpolationHandlerTest()
+    {
+        const string test = "asdf";
+        var boldHello = new SeStringBuilder().AppendBold( "Hello" ).ToReadOnlySeString();
+        Assert.Equal(
+            "Hex:0x    1234\nasdf\nint*: 0x0000000012345678\n|Left|\n<bold(1)>Hello<bold(0)>" ,
+            new SeStringBuilder()
+                .Append( $"Hex:0x{0x1234,8:X}\n{test}\nint*: 0x{(void*) 0x12345678:X16}\n|{"Left",-8}|\n{boldHello}" )
+                .ToReadOnlySeString()
+                .ToString());
+    }
+
+    [Fact]
     public void ThrowsOnInvalidMacroStrings1() =>
         Assert.Throws< MacroStringParseException >( () => new SeStringBuilder().AppendMacroString( "<bad_payload>"u8 ) );
 
@@ -470,11 +483,11 @@ public class SeStringBuilderTests
             {
                 if( gameData.Excel.GetSheetRaw( sheetName, language ) is not { } sheet )
                     continue;
-                
+
                 // CustomTalkDefineClient: it currently fails at reading string columns in sheets of subrow variant. 
                 if( sheet.Variant != ExcelVariant.Default )
                     continue;
-                
+
                 foreach( var row in sheet )
                 {
                     for( var i = 0; i < sheet.Columns.Length; i++ )

--- a/src/Lumina.Tests/SeStringBuilderTests.cs
+++ b/src/Lumina.Tests/SeStringBuilderTests.cs
@@ -431,17 +431,37 @@ public class SeStringBuilderTests
     }
 
     [Fact]
-    public unsafe void InterpolationHandlerTest()
+    public unsafe void InterpolationHandlerTest1()
     {
         const string test = "asdf";
+        Assert.Equal(
+            "Left:1234    \nRight:    1234\nasdf\nint*: 0x0000000012345678",
+            new SeStringBuilder()
+                .Append( $"Left:{0x1234,-8:X}\nRight:{0x1234,8:X}\n{test}\nint*: 0x{(void*) 0x12345678:X16}" )
+                .ToReadOnlySeString()
+                .ToString() );
+    }
+
+    [Fact]
+    public void InterpolationHandlerTest2()
+    {
         var boldHello = new SeStringBuilder().AppendBold( "Hello" ).ToReadOnlySeString();
         Assert.Equal(
-            "Hex:0x    1234\nasdf\nint*: 0x0000000012345678\n|Left|\n<bold(1)>Hello<bold(0)>" ,
+            "|Left    |\n|   Right|\n<bold(1)>Hello<bold(0)>\nnull",
             new SeStringBuilder()
-                .Append( $"Hex:0x{0x1234,8:X}\n{test}\nint*: 0x{(void*) 0x12345678:X16}\n|{"Left",-8}|\n{boldHello}" )
+                .Append( $"|{"Left",-8}|\n|{"Right"u8,8}|\n{boldHello}\n{(object) null}" )
                 .ToReadOnlySeString()
-                .ToString());
+                .ToString() );
     }
+
+    [Fact]
+    public void InterpolationHandlerTest3() =>
+        Assert.Equal(
+            "<italic(1)>test<italic(0)>",
+            new SeStringBuilder()
+                .Append( $"{"<italic(1)>test<italic(0)>":m}" )
+                .ToReadOnlySeString()
+                .ToString() );
 
     [Fact]
     public void ThrowsOnInvalidMacroStrings1() =>

--- a/src/Lumina.Tests/SeStringBuilderTests.cs
+++ b/src/Lumina.Tests/SeStringBuilderTests.cs
@@ -491,6 +491,17 @@ public class SeStringBuilderTests
     public void ThrowsOnInvalidMacroStrings7() =>
         Assert.Throws< MacroStringParseException >( () => new SeStringBuilder().AppendMacroString( "< asdf >"u8 ) );
 
+    [Fact]
+    public void PooledObjectsStateTest()
+    {
+        for( var i = 0; i < 64; i++ )
+        {
+            Assert.Equal(
+                $"{i}<string({i})>{i}<string(<string({i})>)>{i}",
+                ReadOnlySeString.FromMacroString( $"{i}<string({i})>{i}<string(<string({i})>)>{i}" ).ToString() );
+        }
+    }
+    
     [RequiresGameInstallationFact]
     public void AllSheetsTextColumnCodec()
     {

--- a/src/Lumina.Tests/SeStringBuilderTests.cs
+++ b/src/Lumina.Tests/SeStringBuilderTests.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Lumina.Data.Structs.Excel;
 using Lumina.Text;
 using Lumina.Text.Expressions;
+using Lumina.Text.Parse;
 using Lumina.Text.Payloads;
 using Lumina.Text.ReadOnly;
 using Xunit;
@@ -426,6 +427,34 @@ public class SeStringBuilderTests
         }
     }
 
+    [Fact]
+    public void ThrowsOnInvalidMacroStrings1() =>
+        Assert.Throws< MacroStringParseException >( () => new SeStringBuilder().AppendMacroString( "<bad_payload>"u8 ) );
+
+    [Fact]
+    public void ThrowsOnInvalidMacroStrings2() =>
+        Assert.Throws< MacroStringParseException >( () => new SeStringBuilder().AppendMacroString( "<if([a=b])>"u8 ) );
+
+    [Fact]
+    public void ThrowsOnInvalidMacroStrings3() =>
+        Assert.Throws< MacroStringParseException >( () => new SeStringBuilder().AppendMacroString( "<if(1,2,3>"u8 ) );
+
+    [Fact]
+    public void ThrowsOnInvalidMacroStrings4() =>
+        Assert.Throws< MacroStringParseException >( () => new SeStringBuilder().AppendMacroString( "<if,2,3>"u8 ) );
+
+    [Fact]
+    public void ThrowsOnInvalidMacroStrings5() =>
+        Assert.Throws< MacroStringParseException >( () => new SeStringBuilder().AppendMacroString( "<if(1,2,3)"u8 ) );
+
+    [Fact]
+    public void ThrowsOnInvalidMacroStrings6() =>
+        Assert.Throws< MacroStringParseException >( () => new SeStringBuilder().AppendMacroString( "<if(1,2,3"u8 ) );
+
+    [Fact]
+    public void ThrowsOnInvalidMacroStrings7() =>
+        Assert.Throws< MacroStringParseException >( () => new SeStringBuilder().AppendMacroString( "< asdf >"u8 ) );
+
     [RequiresGameInstallationFact]
     public void AllSheetsTextColumnCodec()
     {
@@ -445,7 +474,7 @@ public class SeStringBuilderTests
                     if( sheet.Columns[ i ].Type != ExcelColumnDataType.String )
                         continue;
 
-                    var test1 = row.ReadColumn< SeString >(i).AsReadOnly();
+                    var test1 = row.ReadColumn< SeString >( i ).AsReadOnly();
                     if( test1.Data.Span.IndexOf( "payload:"u8 ) != -1 )
                         throw new( $"Unsupported payload at {sheetName}#{row.RowId}; {test1}" );
 

--- a/src/Lumina/Misc/MemoryChunkStorage.cs
+++ b/src/Lumina/Misc/MemoryChunkStorage.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Lumina.Misc;
+
+/// <summary>Dummy struct for reserving a chunk of memory in stack at compile-time the bat without having to stackalloc.</summary>
+[StructLayout( LayoutKind.Explicit, Size = 256, Pack = 1 )]
+internal struct MemoryChunkStorage
+{
+    /// <summary>Reinterprets a reference of <see cref="MemoryChunkStorage"/> as a <see cref="Span{T}"/> of <typeparamref name="T"/> without zero-initializing.
+    /// </summary>
+    /// <param name="storage">Backing storage.</param>
+    /// <typeparam name="T">Element type.</typeparam>
+    /// <returns><see cref="Span{T}"/>.</returns>
+    /// <remarks>Multiple calls to this function with discard output may result in two instances sharing the memory buffer.</remarks>
+    [MethodImpl( MethodImplOptions.AggressiveInlining )]
+    [SuppressMessage( "ReSharper", "OutParameterValueIsAlwaysDiscarded.Local", Justification = "Stack reservation" )]
+    public static Span< T > AsSpanUninitialized< T >( out MemoryChunkStorage storage ) where T : struct
+    {
+        Unsafe.SkipInit( out storage );
+        return MemoryMarshal.Cast< MemoryChunkStorage, T >( MemoryMarshal.CreateSpan( ref storage, 1 ) );
+    }
+}

--- a/src/Lumina/Text/Expressions/BaseExpression.cs
+++ b/src/Lumina/Text/Expressions/BaseExpression.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 
 namespace Lumina.Text.Expressions;
 
@@ -23,6 +24,18 @@ public abstract class BaseExpression
     /// </summary>
     /// <param name="stream">Target to write this expression to.</param>
     public abstract void Encode( Stream stream );
+
+    /// <summary>Represent this expression as a part of macro string.</summary>
+    /// <param name="sb">Target string builder.</param>
+    public abstract void AppendMacroStringToStringBuilder( StringBuilder sb );
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        var sb = new StringBuilder();
+        AppendMacroStringToStringBuilder( sb );
+        return sb.ToString();
+    }
 
     /// <summary>
     /// Parse given Stream into an Expression.

--- a/src/Lumina/Text/Expressions/BinaryExpression.cs
+++ b/src/Lumina/Text/Expressions/BinaryExpression.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 
 namespace Lumina.Text.Expressions;
 
@@ -37,18 +38,37 @@ public class BinaryExpression : BaseExpression
     public override ExpressionType ExpressionType { get; }
 
     /// <inheritdoc />
-    public override string ToString()
+    public override void AppendMacroStringToStringBuilder( StringBuilder sb )
     {
-        return ExpressionType switch
+        sb.Append( '[' );
+        Operand1.AppendMacroStringToStringBuilder( sb );
+
+        switch( ExpressionType )
         {
-            ExpressionType.GreaterThanOrEqualTo => $"[{Operand1}>={Operand2}]",
-            ExpressionType.GreaterThan => $"[{Operand1}>{Operand2}]",
-            ExpressionType.LessThanOrEqualTo => $"[{Operand1}<={Operand2}]",
-            ExpressionType.LessThan => $"[{Operand1}<{Operand2}]",
-            ExpressionType.Equal => $"[{Operand1}=={Operand2}]",
-            ExpressionType.NotEqual => $"[{Operand1}!={Operand2}]",
-            _ => throw new NotImplementedException() // cannot reach, as this instance is immutable and this field is filtered from constructor
-        };
+            case ExpressionType.GreaterThanOrEqualTo:
+                sb.Append( ">=" );
+                break;
+            case ExpressionType.GreaterThan:
+                sb.Append( '>' );
+                break;
+            case ExpressionType.LessThanOrEqualTo:
+                sb.Append( "<=" );
+                break;
+            case ExpressionType.LessThan:
+                sb.Append( '<' );
+                break;
+            case ExpressionType.Equal:
+                sb.Append( "==" );
+                break;
+            case ExpressionType.NotEqual:
+                sb.Append( "!=" );
+                break;
+            default:
+                throw new NotSupportedException(); // cannot reach, as this instance is immutable and this field is filtered from constructor
+        }
+
+        Operand2.AppendMacroStringToStringBuilder( sb );
+        sb.Append( ']' );
     }
 
     /// <summary>

--- a/src/Lumina/Text/Expressions/IntegerExpression.cs
+++ b/src/Lumina/Text/Expressions/IntegerExpression.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 
 namespace Lumina.Text.Expressions;
 
@@ -93,6 +94,9 @@ public class IntegerExpression : BaseExpression
 
     /// <inheritdoc />
     public override string ToString() => ( (int)Value ).ToString();
+
+    /// <inheritdoc />
+    public override void AppendMacroStringToStringBuilder( StringBuilder sb ) => sb.Append( (int) Value );
 
     /// <summary>
     /// Parse given Stream into an IntegerExpression.

--- a/src/Lumina/Text/Expressions/ParameterExpression.cs
+++ b/src/Lumina/Text/Expressions/ParameterExpression.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 
 namespace Lumina.Text.Expressions;
 
@@ -31,16 +32,17 @@ public class ParameterExpression : BaseExpression
     public override ExpressionType ExpressionType { get; }
 
     /// <inheritdoc />
-    public override string ToString()
+    public override void AppendMacroStringToStringBuilder( StringBuilder sb )
     {
-        return ExpressionType switch
+        sb.Append( ExpressionType switch
         {
-            ExpressionType.IntegerParameter => $"lnum{Operand}",
-            ExpressionType.PlayerParameter => $"gnum{Operand}",
-            ExpressionType.StringParameter => $"lstr{Operand}",
-            ExpressionType.ObjectParameter => $"gstr{Operand}",
-            _ => throw new NotImplementedException() // cannot reach, as this instance is immutable and this field is filtered from constructor
-        };
+            ExpressionType.LocalNumber => "lnum",
+            ExpressionType.GlobalNumber => "gnum",
+            ExpressionType.LocalString => "lstr",
+            ExpressionType.GlobalString => "gstr",
+            _ => throw new NotSupportedException() // cannot reach, as this instance is immutable and this field is filtered from constructor
+        } );
+        Operand.AppendMacroStringToStringBuilder( sb );
     }
 
     /// <summary>

--- a/src/Lumina/Text/Expressions/PlaceholderExpression.cs
+++ b/src/Lumina/Text/Expressions/PlaceholderExpression.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 
 namespace Lumina.Text.Expressions;
 
@@ -28,9 +29,9 @@ public class PlaceholderExpression : BaseExpression
     public override void Encode( Stream stream ) => stream.WriteByte( (byte)ExpressionType );
 
     /// <inheritdoc />
-    public override string ToString()
+    public override void AppendMacroStringToStringBuilder( StringBuilder sb )
     {
-        return ExpressionType switch
+        sb.Append( ExpressionType switch
         {
             ExpressionType.Millisecond => "t_msec",
             ExpressionType.Second => "t_sec",
@@ -41,8 +42,8 @@ public class PlaceholderExpression : BaseExpression
             ExpressionType.Month => "t_mon",
             ExpressionType.Year => "t_year",
             ExpressionType.StackColor => "stackcolor",
-            _ => $"Placeholder#{(byte)ExpressionType:X02}"
-        };
+            _ => $"Placeholder#{(byte) ExpressionType:X02}"
+        } );
     }
 
     /// <summary>

--- a/src/Lumina/Text/Expressions/StringExpression.cs
+++ b/src/Lumina/Text/Expressions/StringExpression.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace Lumina.Text.Expressions;
 
@@ -45,7 +46,8 @@ public class StringExpression : BaseExpression
     }
 
     /// <inheritdoc />
-    public override string ToString() => Value?.ToString() ?? string.Empty;
+    public override void AppendMacroStringToStringBuilder( StringBuilder sb ) =>
+        Value.AppendMacroStringToStringBuilder( sb, true );
 
     /// <summary>
     /// Parse given Stream into a StringExpression.

--- a/src/Lumina/Text/Parse/MacroStringParseException.cs
+++ b/src/Lumina/Text/Parse/MacroStringParseException.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using Lumina.Misc;
 
 namespace Lumina.Text.Parse;
 
@@ -7,9 +9,96 @@ public sealed class MacroStringParseException : InvalidOperationException
 {
     /// <summary>Initializes a new instance of the <see cref="MacroStringParseException"/> class.</summary>
     /// <param name="message">Error message.</param>
-    /// <param name="offset">Byte offset of </param>
-    public MacroStringParseException( string message, int offset ) : base( message ) => Offset = offset;
+    /// <param name="byteOffset">Byte offset in <paramref name="data"/> that caused parse failure.</param>
+    /// <param name="data">Data failed to parse.</param>
+    /// <param name="parseOptions">Options used to parse.</param>
+    public MacroStringParseException( string message, int byteOffset, ReadOnlySpan< byte > data, scoped in MacroStringParseOptions parseOptions )
+        : this(
+            $"{message} at {FormatOffset( byteOffset, data, parseOptions, out var codepointIndex, out var beforeError, out var afterError )}",
+            byteOffset,
+            codepointIndex,
+            beforeError,
+            afterError )
+    { }
 
-    /// <summary>Gets the byte offset of the input string that failed to parse.</summary>
-    public int Offset { get; }
+    private MacroStringParseException( string message, int byteOffset, int codepointIndex, string beforeError, string afterError )
+        : base( message )
+    {
+        ByteOffset = byteOffset;
+        CodepointIndex = codepointIndex;
+        BeforeError = beforeError;
+        AfterError = afterError;
+    }
+
+    /// <summary>Gets the byte offset in the input string that failed to parse.</summary>
+    public int ByteOffset { get; }
+
+    /// <summary>Gets the codepoint index in the input string that failed to parse.</summary>
+    [SuppressMessage( "ReSharper", "UnusedAutoPropertyAccessor.Global", Justification = "Consumers outside the library" )]
+    public int CodepointIndex { get; }
+
+    /// <summary>Gets the text fragment before the error.</summary>
+    [SuppressMessage( "ReSharper", "UnusedAutoPropertyAccessor.Global", Justification = "Consumers outside the library" )]
+    public string BeforeError { get; }
+
+    /// <summary>Gets the text fragment after the error.</summary>
+    [SuppressMessage( "ReSharper", "UnusedAutoPropertyAccessor.Global", Justification = "Consumers outside the library" )]
+    public string AfterError { get; }
+
+    private static string FormatOffset(
+        int byteOffset,
+        ReadOnlySpan< byte > data,
+        scoped in MacroStringParseOptions parseOptions,
+        out int charIndex,
+        out string beforeError,
+        out string afterError )
+    {
+        var storage = MemoryChunkStorage.AsSpanUninitialized< char >( out _ );
+        var prevLen = 0;
+        var nextLen = 0;
+
+        var prevOverflow = false;
+        var nextOverflow = false;
+        charIndex = 0;
+        foreach( var c in new UtfEnumerator( data, parseOptions.CharEnumerationFlags & ~UtfEnumeratorFlags.ErrorHandlingMask ) )
+        {
+            var rune = c.EffectiveRune;
+
+            if( c.ByteOffset >= byteOffset )
+            {
+                var overflow = prevLen + nextLen + rune.Utf16SequenceLength - storage.Length;
+                if( overflow > 0 )
+                {
+                    if( nextLen > storage.Length / 2 )
+                    {
+                        nextOverflow = true;
+                        break;
+                    }
+
+                    storage[ overflow.. ].CopyTo( storage );
+                    prevLen -= overflow;
+                    prevOverflow = true;
+                }
+
+                nextLen += rune.EncodeToUtf16( storage[ ( prevLen + nextLen ).. ] );
+            }
+            else
+            {
+                var overflow = prevLen + rune.Utf16SequenceLength - storage.Length;
+                if( overflow > 0 )
+                {
+                    storage[ overflow.. ].CopyTo( storage );
+                    prevLen -= overflow;
+                    prevOverflow = true;
+                }
+
+                prevLen += rune.EncodeToUtf16( storage[ prevLen.. ] );
+                charIndex++;
+            }
+        }
+
+        beforeError = ( prevOverflow ? "..." : "" ) + storage[ ..prevLen ].ToString();
+        afterError = storage.Slice( prevLen, nextLen ).ToString() + ( nextOverflow ? "..." : "" );
+        return $"{charIndex} (byte offset at {byteOffset}); \"{beforeError}\" ^^^^^ \"{afterError}\"";
+    }
 }

--- a/src/Lumina/Text/Parse/MacroStringParseException.cs
+++ b/src/Lumina/Text/Parse/MacroStringParseException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Lumina.Text.Parse;
+
+/// <summary>Exception thrown when macro string parsing has failed.</summary>
+public sealed class MacroStringParseException : InvalidOperationException
+{
+    /// <summary>Initializes a new instance of the <see cref="MacroStringParseException"/> class.</summary>
+    /// <param name="message">Error message.</param>
+    /// <param name="offset">Byte offset of </param>
+    public MacroStringParseException( string message, int offset ) : base( message ) => Offset = offset;
+
+    /// <summary>Gets the byte offset of the input string that failed to parse.</summary>
+    public int Offset { get; }
+}

--- a/src/Lumina/Text/Parse/MacroStringParseExceptionMode.cs
+++ b/src/Lumina/Text/Parse/MacroStringParseExceptionMode.cs
@@ -1,0 +1,14 @@
+namespace Lumina.Text.Parse;
+
+/// <summary>Specify the action on macro string parse failure.</summary>
+public enum MacroStringParseExceptionMode
+{
+    /// <summary>Throw a <see cref="MacroStringParseException"/> on failure.</summary>
+    Throw,
+
+    /// <summary>Write the error message as a string into <see cref="SeStringBuilder"/>.</summary>
+    EmbedError,
+
+    /// <summary>Ignores the error and instead write the problematic part as plaintext.</summary>
+    Ignore,
+}

--- a/src/Lumina/Text/Parse/MacroStringParseOptions.cs
+++ b/src/Lumina/Text/Parse/MacroStringParseOptions.cs
@@ -1,0 +1,10 @@
+namespace Lumina.Text.Parse;
+
+/// <summary>
+/// Options for <see cref="SeStringBuilder.AppendMacroString"/>.
+/// </summary>
+/// <param name="CharEnumerationFlags">Specify how to interpret the text given.</param>
+/// <param name="ExceptionMode"></param>
+public readonly record struct MacroStringParseOptions(
+    UtfEnumeratorFlags CharEnumerationFlags = UtfEnumeratorFlags.Default,
+    MacroStringParseExceptionMode ExceptionMode = MacroStringParseExceptionMode.Throw );

--- a/src/Lumina/Text/Parse/MacroStringParser.cs
+++ b/src/Lumina/Text/Parse/MacroStringParser.cs
@@ -448,7 +448,7 @@ internal readonly ref struct MacroStringParser
 
         macroCodeName = macroCodeName[ ..macroCodeNameLength ];
 
-        foreach( var n in Enum.GetValues< MacroCode >() )
+        foreach( var n in MacroCodeExtensions.GetDefinedMacroCodes())
         {
             if( macroCodeName.SequenceEqual( n.GetEncodeName() ) )
             {

--- a/src/Lumina/Text/Parse/MacroStringParser.cs
+++ b/src/Lumina/Text/Parse/MacroStringParser.cs
@@ -366,18 +366,18 @@ internal readonly ref struct MacroStringParser
                 data = data[ 1.. ];
             } while( !data.IsEmpty );
 
-            var maxPerDigit = 10;
+            var maxPerDigit = 10u;
             if( data.Length > 2 && data[ 0 ] == '0' )
             {
                 maxPerDigit = (char) data[ 1 ] switch
                 {
-                    'x' or 'X' => 16,
-                    'o' or 'O' => 8,
-                    'b' or 'B' => 2,
-                    'd' or 'D' => 10,
-                    _ => 0
+                    'x' or 'X' => 16u,
+                    'o' or 'O' => 8u,
+                    'b' or 'B' => 2u,
+                    'd' or 'D' => 10u,
+                    _ => 0u
                 };
-                if( maxPerDigit == 0 )
+                if( maxPerDigit == 0u )
                     return false;
                 data = data[ 2.. ];
             }
@@ -389,11 +389,11 @@ internal readonly ref struct MacroStringParser
             foreach( var d in data )
             {
                 var digit = d >= Digits.Length ? -1 : Digits[ d ];
-                if( digit == -1 || digit > maxPerDigit )
+                if( digit == -1 || digit >= maxPerDigit )
                     return false;
                 if( digit == -2 )
                     continue;
-                num = unchecked( num * 10u + (uint) digit );
+                num = unchecked( num * maxPerDigit + (uint) digit );
             }
 
             result = unchecked( sign * (int) num );

--- a/src/Lumina/Text/Parse/MacroStringParser.cs
+++ b/src/Lumina/Text/Parse/MacroStringParser.cs
@@ -1,0 +1,481 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using Lumina.Text.Expressions;
+using Lumina.Text.Payloads;
+using Lumina.Text.ReadOnly;
+
+namespace Lumina.Text.Parse;
+
+internal readonly ref struct MacroStringParser
+{
+    // Map from ascii code to supposed number.
+    // -1 = invalid, -2 = ignore.
+    private static readonly sbyte[] Digits =
+    [
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -2, -1, -1, -1, -1, -1, -1, -1, -1, // _
+        +0, +1, +2, +3, +4, +5, +6, +7, +8, +9, -1, -1, -1, -1, -1, -1, // 0-9
+        10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // A-F
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -2, // '
+        10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // a-f
+    ];
+
+    private readonly ReadOnlySpan< byte > _macroString;
+    private readonly UtfEnumeratorFlags _utfEnumeratorFlags;
+    private readonly SeStringBuilder _builder;
+    private readonly MacroStringParseExceptionMode _exceptionMode;
+
+    internal MacroStringParser(
+        ReadOnlySpan< byte > macroString,
+        UtfEnumeratorFlags utfEnumeratorFlags,
+        SeStringBuilder builder,
+        MacroStringParseExceptionMode exceptionMode )
+    {
+        _macroString = macroString;
+        _utfEnumeratorFlags = utfEnumeratorFlags;
+        _builder = builder;
+        _exceptionMode = exceptionMode;
+    }
+
+    /// <summary>Parses the macro string.</summary>
+    /// <returns>The builder.</returns>
+    public int ParseMacroStringAndAppend( int offset, bool stopOnCharRequiringEscape, ReadOnlySpan< byte > extraTerminators )
+    {
+        var beginOffset = offset;
+        while( new UtfEnumerator( _macroString[ offset.. ], _utfEnumeratorFlags ).TryPeekNext( out var s, out _ ) )
+        {
+            switch( s.Value.UIntValue )
+            {
+                case '\\':
+                    offset += ParseMacroStringTextAndAppend( offset, extraTerminators );
+                    break;
+
+                case <= byte.MaxValue when extraTerminators.Contains( (byte) s.Value.UIntValue ):
+                    return offset - beginOffset;
+
+                case '<':
+                    try
+                    {
+                        offset += ParseMacroStringPayloadAndAppend( offset, extraTerminators );
+                    }
+                    catch( MacroStringParseException e )
+                    {
+                        if( _exceptionMode is MacroStringParseExceptionMode.Throw )
+                            throw;
+
+                        var byteLength = Math.Max( s.ByteLength, e.Offset - offset );
+                        var sliceUntilError = _macroString.Slice( offset, byteLength );
+                        switch( _utfEnumeratorFlags & UtfEnumeratorFlags.UtfMask )
+                        {
+                            case UtfEnumeratorFlags.Utf8:
+                                _builder.Append( sliceUntilError );
+                                break;
+                            case UtfEnumeratorFlags.Utf8SeString:
+                                _builder.Append( new ReadOnlySeStringSpan( sliceUntilError ) );
+                                break;
+                            case UtfEnumeratorFlags.Utf16:
+                                _builder.Append( MemoryMarshal.Cast< byte, char >( sliceUntilError ) );
+                                break;
+                            case UtfEnumeratorFlags.Utf32:
+                                var dummy = 0;
+                                var dummyAsSpan = MemoryMarshal.Cast< int, byte >( MemoryMarshal.CreateSpan( ref dummy, 1 ) );
+                                foreach( var r in MemoryMarshal.Cast< byte, Rune >( sliceUntilError ) )
+                                    _builder.Append( dummyAsSpan[ ..r.EncodeToUtf8( dummyAsSpan ) ] );
+                                break;
+                        }
+
+                        if( _exceptionMode == MacroStringParseExceptionMode.EmbedError )
+                            _builder.Append( "<ERROR: " ).Append( e.Message ).Append( ">" );
+                        offset += byteLength;
+                    }
+
+                    break;
+
+                case <= byte.MaxValue when CharRequiresEscapeInSeString( s.Value.UIntValue ):
+                    if( stopOnCharRequiringEscape )
+                        return offset - beginOffset;
+
+                    var v = unchecked( (byte) s.Value.UIntValue );
+                    _builder.Append( MemoryMarshal.CreateReadOnlySpan( ref v, 1 ) );
+                    offset += s.ByteLength;
+                    break;
+
+                default:
+                    offset += ParseMacroStringTextAndAppend( offset, extraTerminators );
+                    break;
+            }
+        }
+
+        return offset - beginOffset;
+    }
+
+    private int ParseMacroStringTextAndAppend( int offset, ReadOnlySpan< byte > extraTerminators )
+    {
+        var nextIsEscaped = false;
+        foreach( var c in new UtfEnumerator( _macroString[ offset.. ], _utfEnumeratorFlags ) )
+        {
+            switch( c.Value.UIntValue )
+            {
+                case var _ when nextIsEscaped:
+                    nextIsEscaped = false;
+                    goto default;
+                case '\\':
+                    nextIsEscaped = true;
+                    break;
+                case var _ when CharRequiresEscapeInSeString( c.Value ):
+                case var b and <= byte.MaxValue when extraTerminators.Contains( (byte) b ):
+                    return c.ByteOffset;
+                default:
+                    // making a 4 byte buffer:
+                    var buf = 0;
+                    var bufSpan = MemoryMarshal.Cast< int, byte >( MemoryMarshal.CreateSpan( ref buf, 1 ) );
+                    _builder.Append( bufSpan[ ..c.EffectiveRune.EncodeToUtf8( bufSpan ) ] );
+                    break;
+            }
+        }
+
+        return _macroString.Length - offset;
+    }
+
+    private int ParseMacroStringPayloadAndAppend( int offset, ReadOnlySpan< byte > extraTerminators )
+    {
+        var beginOffset = offset;
+        ConsumeStart( ref offset, "<"u8 );
+        SkipWhitespaces( ref offset );
+        var macroCode = ParseMacroCode( ref offset );
+        SkipWhitespaces( ref offset );
+
+        _builder.BeginMacro( macroCode );
+
+        var macroBuildSuccess = false;
+        try
+        {
+            if( TryConsumeStart( ref offset, "("u8 ) )
+            {
+                var first = true;
+                while( true )
+                {
+                    if( offset >= _macroString.Length )
+                        throw new MacroStringParseException( "Unexpected EOF", offset );
+
+                    if( TryConsumeStart( ref offset, ")"u8 ) )
+                        break;
+
+                    if( first )
+                        first = false;
+                    else
+                        ConsumeStart( ref offset, ","u8 );
+
+                    offset += ParseMacroStringExpressionAndAppend( offset, extraTerminators );
+                }
+
+                SkipWhitespaces( ref offset );
+            }
+
+            ConsumeStart( ref offset, ">"u8 );
+            macroBuildSuccess = true;
+            return offset - beginOffset;
+        }
+        finally
+        {
+            if( macroBuildSuccess )
+                _builder.EndMacro();
+            else
+                _builder.AbortMacro();
+        }
+    }
+
+    private int ParseMacroStringExpressionAndAppend( int offset, ReadOnlySpan< byte > extraTerminators )
+    {
+        var abortExpression = false;
+
+        try
+        {
+            var beginOffset = offset;
+            if( TryConsumeStart( ref offset, "["u8 ) )
+            {
+                _builder.BeginBinaryExpression( ExpressionType.Equal );
+
+                abortExpression = true;
+                offset += ParseMacroStringExpressionAndAppend( offset, "=!<>"u8 );
+
+                var op1 = -1;
+                var op2 = -1;
+                var len1 = 0;
+                var len2 = 0;
+                foreach( var e in new UtfEnumerator( _macroString[ offset.. ], _utfEnumeratorFlags ) )
+                {
+                    var c = e.Value.IntValue is '!' or '=' or '<' or '>' ? e.Value.IntValue : 0;
+                    if( c == 0 )
+                        break;
+
+                    if( op1 == -1 )
+                    {
+                        op1 = (byte) c;
+                        len1 = e.ByteLength;
+                    }
+                    else
+                    {
+                        op2 = (byte) c;
+                        len2 = e.ByteLength;
+                        break;
+                    }
+                }
+
+                switch( op1 )
+                {
+                    case '=' when op2 == '=':
+                        offset += len1 + len2;
+                        _builder.ChangeBinaryExpression( ExpressionType.Equal );
+                        break;
+                    case '!' when op2 == '=':
+                        offset += len1 + len2;
+                        _builder.ChangeBinaryExpression( ExpressionType.NotEqual );
+                        break;
+                    case '<' when op2 == '=':
+                        offset += len1 + len2;
+                        _builder.ChangeBinaryExpression( ExpressionType.LessThanOrEqualTo );
+                        break;
+                    case '<':
+                        offset += len1;
+                        _builder.ChangeBinaryExpression( ExpressionType.LessThan );
+                        break;
+                    case '>' when op2 == '=':
+                        offset += len1 + len2;
+                        _builder.ChangeBinaryExpression( ExpressionType.GreaterThanOrEqualTo );
+                        break;
+                    case '>':
+                        offset += len1;
+                        _builder.ChangeBinaryExpression( ExpressionType.GreaterThan );
+                        break;
+                    default:
+                        throw new MacroStringParseException( $"Unsupported binary expression: {(char) op1}{(char) op2}", offset );
+                }
+
+                offset += ParseMacroStringExpressionAndAppend( offset, extraTerminators );
+                ConsumeStart( ref offset, "]"u8 );
+
+                abortExpression = false;
+                _builder.EndExpression();
+                return offset - beginOffset;
+            }
+
+            _builder.BeginStringExpression();
+
+            abortExpression = true;
+            var length = ParseMacroStringAndAppend( offset, true, extraTerminators );
+            abortExpression = false;
+
+            var text8 = _macroString.Slice( offset, length );
+            if( ( _utfEnumeratorFlags & UtfEnumeratorFlags.UtfMask ) is not UtfEnumeratorFlags.Utf8 and not UtfEnumeratorFlags.Utf8SeString )
+            {
+                var text8Length = 0;
+                foreach( var e in new UtfEnumerator( text8, _utfEnumeratorFlags ) )
+                    text8Length += e.EffectiveRune.Utf8SequenceLength;
+
+                var tmp = text8Length < 1024 ? stackalloc byte[text8Length] : new byte[text8Length];
+                var tmpOffset = 0;
+                foreach( var e in new UtfEnumerator( text8, _utfEnumeratorFlags ) )
+                    tmpOffset += e.EffectiveRune.EncodeToUtf8( tmp[ tmpOffset.. ] );
+
+                TransformStringExpression( tmp );
+            }
+            else
+            {
+                TransformStringExpression( text8 );
+            }
+
+            return length;
+        }
+        finally
+        {
+            if( abortExpression )
+                _builder.AbortExpression();
+        }
+    }
+
+    private void TransformStringExpression( ReadOnlySpan< byte > text8 )
+    {
+        if( text8.StartsWith( "lnum"u8 ) && TryParseInt( text8[ 4.. ], out var parsedInt ) )
+            _builder.AbortExpression().AppendLocalNumberExpression( parsedInt );
+        else if( text8.StartsWith( "lstr"u8 ) && TryParseInt( text8[ 4.. ], out parsedInt ) )
+            _builder.AbortExpression().AppendLocalStringExpression( parsedInt );
+        else if( text8.StartsWith( "gnum"u8 ) && TryParseInt( text8[ 4.. ], out parsedInt ) )
+            _builder.AbortExpression().AppendGlobalNumberExpression( parsedInt );
+        else if( text8.StartsWith( "gstr"u8 ) && TryParseInt( text8[ 4.. ], out parsedInt ) )
+            _builder.AbortExpression().AppendGlobalStringExpression( parsedInt );
+        else if( text8.SequenceEqual( "t_msec"u8 ) )
+            _builder.AbortExpression().AppendNullaryExpression( ExpressionType.Millisecond );
+        else if( text8.SequenceEqual( "t_sec"u8 ) )
+            _builder.AbortExpression().AppendNullaryExpression( ExpressionType.Second );
+        else if( text8.SequenceEqual( "t_min"u8 ) )
+            _builder.AbortExpression().AppendNullaryExpression( ExpressionType.Minute );
+        else if( text8.SequenceEqual( "t_hour"u8 ) )
+            _builder.AbortExpression().AppendNullaryExpression( ExpressionType.Hour );
+        else if( text8.SequenceEqual( "t_day"u8 ) )
+            _builder.AbortExpression().AppendNullaryExpression( ExpressionType.Day );
+        else if( text8.SequenceEqual( "t_wday"u8 ) )
+            _builder.AbortExpression().AppendNullaryExpression( ExpressionType.Weekday );
+        else if( text8.SequenceEqual( "t_mon"u8 ) )
+            _builder.AbortExpression().AppendNullaryExpression( ExpressionType.Month );
+        else if( text8.SequenceEqual( "t_year"u8 ) )
+            _builder.AbortExpression().AppendNullaryExpression( ExpressionType.Year );
+        else if( text8.SequenceEqual( "stackcolor"u8 ) )
+            _builder.AbortExpression().AppendNullaryExpression( ExpressionType.StackColor );
+        else if( TryParseInt( text8, out parsedInt ) )
+            _builder.AbortExpression().AppendIntExpression( parsedInt );
+        else
+            _builder.EndExpression();
+
+        return;
+
+        static bool TryParseInt( ReadOnlySpan< byte > data, out int result )
+        {
+            result = 0;
+            if( data.IsEmpty )
+                return false;
+
+            var sign = 1;
+            do
+            {
+                if( data[ 0 ] == '-' )
+                    sign *= -1;
+                else if( data[ 0 ] == '+' )
+                    sign *= 1;
+                else if( data[ 0 ] >= '0' && data[ 0 ] <= '9' )
+                    break;
+                else
+                    return false;
+                data = data[ 1.. ];
+            } while( !data.IsEmpty );
+
+            var maxPerDigit = 10;
+            if( data.Length > 2 && data[ 0 ] == '0' )
+            {
+                maxPerDigit = (char) data[ 1 ] switch
+                {
+                    'x' or 'X' => 16,
+                    'o' or 'O' => 8,
+                    'b' or 'B' => 2,
+                    'd' or 'D' => 10,
+                    _ => 0
+                };
+                if( maxPerDigit == 0 )
+                    return false;
+                data = data[ 2.. ];
+            }
+
+            if( data.IsEmpty )
+                return false;
+
+            var num = 0u;
+            foreach( var d in data )
+            {
+                var digit = d >= Digits.Length ? -1 : Digits[ d ];
+                if( digit == -1 || digit > maxPerDigit )
+                    return false;
+                if( digit == -2 )
+                    continue;
+                num = unchecked( num * 10u + (uint) digit );
+            }
+
+            result = unchecked( sign * (int) num );
+            return true;
+        }
+    }
+
+    private bool TryConsumeStart( ref int offset, ReadOnlySpan< byte > expected )
+    {
+        var en1 = new UtfEnumerator( _macroString[ offset.. ], _utfEnumeratorFlags );
+        var en2 = new UtfEnumerator( expected, UtfEnumeratorFlags.Utf8 );
+        if( !en1.MoveNext() || !en2.MoveNext() )
+            return false;
+
+        int off1, off2;
+        do
+        {
+            if( en1.Current.Value != en2.Current.Value )
+                return false;
+            off1 = en1.Current.ByteOffset + en1.Current.ByteLength;
+            off2 = en2.Current.ByteOffset + en2.Current.ByteLength;
+        } while( en1.MoveNext() && en2.MoveNext() );
+
+        if( off2 != expected.Length )
+            return false;
+
+        offset += off1;
+        return true;
+    }
+
+    private void ConsumeStart( ref int offset, ReadOnlySpan< byte > expected )
+    {
+        if( !TryConsumeStart( ref offset, expected ) )
+            throw new MacroStringParseException( $"Expected \"{Encoding.UTF8.GetString( expected )}\"", offset );
+    }
+
+    private MacroCode ParseMacroCode( ref int offset )
+    {
+        Span< char > macroCodeName = stackalloc char[64];
+        var macroCodeNameLength = 0;
+
+        var numConsumedBytes = _macroString.Length - offset;
+        var nextIsEscaped = false;
+        foreach( var c in new UtfEnumerator( _macroString[ offset.. ], _utfEnumeratorFlags ) )
+        {
+            var stop = false;
+            switch( c.Value.IntValue )
+            {
+                case var _ when nextIsEscaped:
+                    nextIsEscaped = false;
+                    goto default;
+                case '\\':
+                    nextIsEscaped = true;
+                    break;
+                case var _ when CharRequiresEscapeInSeString( c.Value ) || Rune.IsWhiteSpace( c.EffectiveRune ):
+                    numConsumedBytes = c.ByteOffset;
+                    stop = true;
+                    break;
+                default:
+                    macroCodeNameLength += c.EffectiveRune.TryEncodeToUtf16( macroCodeName[ macroCodeNameLength.. ], out var written )
+                        ? written
+                        : throw new MacroStringParseException( $"Unsupported {nameof( MacroCode )}: \"{macroCodeName[ ..macroCodeNameLength ]}...\"", offset );
+                    break;
+            }
+
+            if( stop )
+                break;
+        }
+
+        macroCodeName = macroCodeName[ ..macroCodeNameLength ];
+
+        foreach( var n in Enum.GetValues< MacroCode >() )
+        {
+            if( macroCodeName.SequenceEqual( n.GetEncodeName() ) )
+            {
+                offset += numConsumedBytes;
+                return n;
+            }
+        }
+
+        throw new MacroStringParseException( $"Unsupported {nameof( MacroCode )}: \"{macroCodeName}\"", offset );
+    }
+
+    private void SkipWhitespaces( ref int offset )
+    {
+        foreach( var c in new UtfEnumerator( _macroString[ offset.. ], _utfEnumeratorFlags ) )
+        {
+            if( c.Value.TryGetRune( out var rune ) && Rune.IsWhiteSpace( rune ) )
+                continue;
+
+            offset += c.ByteOffset;
+            return;
+        }
+
+        offset = _macroString.Length;
+    }
+
+    private static bool CharRequiresEscapeInSeString( uint c ) =>
+        c is '\\' or ',' or '<' or '>' or '(' or ')' or '[' or ']';
+}

--- a/src/Lumina/Text/Parse/MacroStringParser.cs
+++ b/src/Lumina/Text/Parse/MacroStringParser.cs
@@ -165,7 +165,7 @@ internal readonly ref struct MacroStringParser
                     if( first )
                         first = false;
                     else
-                        ConsumeStart( ref offset, ","u8 );
+                        ConsumeStart( ref offset, ","u8, "\",\" or \")\"" );
 
                     offset += ParseMacroStringExpressionAndAppend( offset, extraTerminators );
                 }
@@ -424,10 +424,13 @@ internal readonly ref struct MacroStringParser
         return true;
     }
 
-    private void ConsumeStart( ref int offset, ReadOnlySpan< byte > expected )
+    private void ConsumeStart( ref int offset, ReadOnlySpan< byte > expected, string? expectedRepresentationForException = null )
     {
-        if( !TryConsumeStart( ref offset, expected ) )
-            throw new MacroStringParseException( $"Expected \"{Encoding.UTF8.GetString( expected )}\"", offset );
+        if( TryConsumeStart( ref offset, expected ) )
+            return;
+
+        expectedRepresentationForException ??= $"\"{Encoding.UTF8.GetString( expected )}\"";
+        throw new MacroStringParseException( $"Expected {expectedRepresentationForException}", offset );
     }
 
     private MacroCode ParseMacroCode( ref int offset )

--- a/src/Lumina/Text/Payloads/BasePayload.cs
+++ b/src/Lumina/Text/Payloads/BasePayload.cs
@@ -256,5 +256,45 @@ namespace Lumina.Text.Payloads
                 ex => ex is StringExpression se ? se.Value.ToMacroString() : ex.ToString()
             ) )})>";
         }
+
+        internal void AppendMacroStringToStringBuilder( StringBuilder sb, bool forStringExpression )
+        {
+            if( PayloadType == PayloadType.Text )
+            {
+                foreach( var c in RawString )
+                {
+                    switch( forStringExpression )
+                    {
+                        case true when c is '<' or '>' or '[' or ']' or '(' or ')' or ',' or '\\':
+                        case false when c is '<' or '\\':
+                            sb.Append( '\\' );
+                            break;
+                    }
+
+                    sb.Append( c );
+                }
+
+                return;
+            }
+
+            sb.Append( $"<{( (MacroCode) PayloadType ).GetEncodeName()}" );
+            if( Expressions.Count > 0 )
+            {
+                sb.Append( '(' );
+                Expressions[ 0 ].AppendMacroStringToStringBuilder( sb );
+                if( Expressions.Count > 1 )
+                {
+                    for( var i = 1; i < Expressions.Count; i++ )
+                    {
+                        sb.Append( ',' );
+                        Expressions[ i ].AppendMacroStringToStringBuilder( sb );
+                    }
+                }
+
+                sb.Append( ')' );
+            }
+
+            sb.Append( '>' );
+        }
     }
 }

--- a/src/Lumina/Text/Payloads/MacroCode.cs
+++ b/src/Lumina/Text/Payloads/MacroCode.cs
@@ -4,9 +4,6 @@ namespace Lumina.Text.Payloads;
 /// <remarks>A <c>terminator</c> argument does not mean that an argument is required.</remarks>
 public enum MacroCode : byte
 {
-    /// <summary>Not a valid macro code. Representation for <c>default(MacroCode)</c>.</summary>
-    Invalid = 0,
-
     /// <summary>Sets the reset time to the contextual time storage.</summary>
     /// <remarks>Parameters: weekday, hour, terminator.</remarks>
     [MacroCodeData( null, "n N x" )] SetResetTime = 0x06,

--- a/src/Lumina/Text/Payloads/MacroCode.cs
+++ b/src/Lumina/Text/Payloads/MacroCode.cs
@@ -4,6 +4,9 @@ namespace Lumina.Text.Payloads;
 /// <remarks>A <c>terminator</c> argument does not mean that an argument is required.</remarks>
 public enum MacroCode : byte
 {
+    /// <summary>Not a valid macro code. Representation for <c>default(MacroCode)</c>.</summary>
+    Invalid = 0,
+
     /// <summary>Sets the reset time to the contextual time storage.</summary>
     /// <remarks>Parameters: weekday, hour, terminator.</remarks>
     [MacroCodeData( null, "n N x" )] SetResetTime = 0x06,

--- a/src/Lumina/Text/Payloads/MacroCodeExtensions.cs
+++ b/src/Lumina/Text/Payloads/MacroCodeExtensions.cs
@@ -7,7 +7,7 @@ namespace Lumina.Text.Payloads;
 /// <summary>Extension methods for <see cref="MacroCode"/>.</summary>
 public static class MacroCodeExtensions
 {
-    private static readonly MacroCode[] _definedMacroCodes = Enum.GetValues< MacroCode >().Where( x => x != MacroCode.Invalid ).ToArray();
+    private static readonly MacroCode[] DefinedMacroCodes = Enum.GetValues< MacroCode >();
     private static readonly string?[] EncodedNames;
 
     static MacroCodeExtensions()
@@ -25,9 +25,9 @@ public static class MacroCodeExtensions
 
     /// <summary>Gets all the defined macro codes.</summary>
     /// <returns>Read-only span of macro codes.</returns>
-    public static ReadOnlySpan< MacroCode > GetDefinedMacroCodes() => _definedMacroCodes;
+    public static ReadOnlySpan< MacroCode > GetDefinedMacroCodes() => DefinedMacroCodes;
 
-    /// <summary>Gets the encoded name for an macro code, if available.</summary>
+    /// <summary>Gets the encoded name for a macro code, if available.</summary>
     /// <param name="v">The macro code.</param>
     /// <returns>The native name of the macro code, or <c>null</c> if not available.</returns>
     public static string? GetEncodeName( this MacroCode v ) => EncodedNames[ (int) v ];

--- a/src/Lumina/Text/Payloads/MacroCodeExtensions.cs
+++ b/src/Lumina/Text/Payloads/MacroCodeExtensions.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using System.Reflection;
 
 namespace Lumina.Text.Payloads;
@@ -5,6 +7,7 @@ namespace Lumina.Text.Payloads;
 /// <summary>Extension methods for <see cref="MacroCode"/>.</summary>
 public static class MacroCodeExtensions
 {
+    private static readonly MacroCode[] _definedMacroCodes = Enum.GetValues< MacroCode >().Where( x => x != MacroCode.Invalid ).ToArray();
     private static readonly string?[] EncodedNames;
 
     static MacroCodeExtensions()
@@ -19,6 +22,10 @@ public static class MacroCodeExtensions
             EncodedNames[ b ] = mcda.EncodedName ?? v.Name.ToLowerInvariant();
         }
     }
+
+    /// <summary>Gets all the defined macro codes.</summary>
+    /// <returns>Read-only span of macro codes.</returns>
+    public static ReadOnlySpan< MacroCode > GetDefinedMacroCodes() => _definedMacroCodes;
 
     /// <summary>Gets the encoded name for an macro code, if available.</summary>
     /// <param name="v">The macro code.</param>

--- a/src/Lumina/Text/ReadOnly/ReadOnlySePayloadSpan.cs
+++ b/src/Lumina/Text/ReadOnly/ReadOnlySePayloadSpan.cs
@@ -427,45 +427,80 @@ public readonly ref struct ReadOnlySePayloadSpan
     /// <inheritdoc/>
     public override string ToString()
     {
+        var sb = new StringBuilder();
+        AppendMacroStringToStringBuilder( sb, false );
+        return sb.ToString();
+    }
+
+    /// <summary>Writes the encodeable macro representation of this instance of <see cref="ReadOnlySePayloadSpan"/> to the given string builder.</summary>
+    /// <param name="sb">Target string builder.</param>
+    /// <param name="forStringExpression">Whether this is being encoded to be used as a string expression.</param>
+    /// <returns>The encodeable macro representation.</returns>
+    public void AppendMacroStringToStringBuilder( StringBuilder sb, bool forStringExpression )
+    {
         switch( Type )
         {
             case ReadOnlySePayloadType.Text:
-                return Encoding.UTF8.GetString( Body ).Replace( "<", "\\<" );
+            {
+                var remaining = Body;
+                Span< char > buf = stackalloc char[2];
+                while( !remaining.IsEmpty )
+                {
+                    Rune.DecodeFromUtf8( remaining, out var rune, out var consumed );
+                    switch( forStringExpression )
+                    {
+                        case true when rune.Value is '<' or '>' or '[' or ']' or '(' or ')' or ',' or '\\':
+                        case false when rune.Value is '<' or '\\':
+                            sb.Append( '\\' );
+                            break;
+                    }
+
+                    sb.Append( buf[ ..rune.EncodeToUtf16( buf ) ] );
+                    remaining = remaining[ consumed.. ];
+                }
+
+                break;
+            }
 
             case ReadOnlySePayloadType.Macro:
             {
-                var sb = new StringBuilder( "<" );
+                sb.Append( '<' );
 
                 // Not using ternary operator here, as it's better to let StringBuilder handle the string interpolation.
                 if( MacroCode.GetEncodeName() is { } encodeName )
                     sb.Append( encodeName );
                 else
-                    sb.Append( $"x{(uint) MacroCode:X02}" );
+                    sb.Append( $"payload:{(uint) MacroCode:X02}" );
 
                 var expre = GetEnumerator();
                 if( expre.MoveNext() )
                 {
                     sb.Append( '(' );
-                    sb.Append( expre.Current.ToString() );
+                    expre.Current.AppendMacroStringToStringBuilder( sb );
                     while( expre.MoveNext() )
-                        sb.Append( ", " ).Append( expre.Current.ToString() );
+                    {
+                        sb.Append( ',' );
+                        expre.Current.AppendMacroStringToStringBuilder( sb );
+                    }
+
                     sb.Append( ')' );
                 }
 
-                return sb.Append( '>' ).ToString();
+                sb.Append( '>' );
+                break;
             }
 
             case var _ when Body.Length == 0:
-                return "<?>";
+                sb.Append( "<payload: invalid empty>" );
+                break;
 
             default:
-            {
-                var sb = new StringBuilder( 3 * Body.Length + 3 );
-                sb.Append( "<?" );
-                foreach (var b in Body)
+                sb.EnsureCapacity( sb.Length + 10 + 3 * Body.Length );
+                sb.Append( "<payload:" );
+                foreach( var b in Body )
                     sb.Append( $" {b:X02}" );
-                return sb.Append( '>' ).ToString();
-            }
+                sb.Append( '>' );
+                break;
         }
     }
 

--- a/src/Lumina/Text/ReadOnly/ReadOnlySeString.cs
+++ b/src/Lumina/Text/ReadOnly/ReadOnlySeString.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
+using Lumina.Text.Parse;
 using Lumina.Text.Payloads;
 
 namespace Lumina.Text.ReadOnly;
@@ -269,6 +270,32 @@ public readonly struct ReadOnlySeString : IEquatable< ReadOnlySeString >, IReadO
     /// <param name="text">Text to create a new <see cref="ReadOnlySeString"/> from.</param>
     /// <returns>A new instance of <see cref="ReadOnlySeString"/>, independent of the backing memory of <paramref name="text"/>.</returns>
     public static ReadOnlySeString FromText( ReadOnlySpan< char > text ) => new( text );
+
+    /// <summary>Creates a new instance of the <see cref="ReadOnlySeString"/> struct from the given macro string.</summary>
+    /// <param name="macroString">String to parse and add.</param>
+    /// <param name="parseOptions">Parse options for <paramref cref="macroString"/>. Defaults to interpreting <paramref name="macroString"/> as UTF-8.</param>
+    /// <returns>A reference of this instance after the append operation is completed.</returns>
+    public static ReadOnlySeString FromMacroString( ReadOnlySpan< byte > macroString, MacroStringParseOptions parseOptions = default )
+    {
+        var ssb = SeStringBuilder.SharedPool.Get();
+        ssb.AppendMacroString( macroString, parseOptions );
+        var res = ssb.ToReadOnlySeString();
+        SeStringBuilder.SharedPool.Return( ssb );
+        return res;
+    }
+
+    /// <summary>Creates a new instance of the <see cref="ReadOnlySeString"/> struct from the given macro string.</summary>
+    /// <param name="macroString">String to parse and add.</param>
+    /// <param name="parseOptions">Parse options for <paramref cref="macroString"/>. Defaults to interpreting <paramref name="macroString"/> as UTF-16.</param>
+    /// <returns>A reference of this instance after the append operation is completed.</returns>
+    public static ReadOnlySeString FromMacroString( ReadOnlySpan< char > macroString, MacroStringParseOptions parseOptions = default )
+    {
+        var ssb = SeStringBuilder.SharedPool.Get();
+        ssb.AppendMacroString( macroString, parseOptions );
+        var res = ssb.ToReadOnlySeString();
+        SeStringBuilder.SharedPool.Return( ssb );
+        return res;
+    }
 
     /// <summary>Gets a <see cref="ReadOnlySeStringSpan"/> from this <see cref="ReadOnlySeString"/>.</summary>
     /// <returns>A new instance of <see cref="ReadOnlySeStringSpan"/>.</returns>

--- a/src/Lumina/Text/ReadOnly/ReadOnlySeString.cs
+++ b/src/Lumina/Text/ReadOnly/ReadOnlySeString.cs
@@ -23,9 +23,55 @@ public readonly struct ReadOnlySeString : IEquatable< ReadOnlySeString >, IReadO
     public readonly ReadOnlyMemory< byte > Data;
 
     /// <summary>Initializes a new instance of the <see cref="ReadOnlySeString"/> struct.</summary>
+    /// <param name="data">Raw SeString data to copy from.</param>
+    /// <remarks>Data is copied from <paramref name="data"/>; this function is not allocation-free.</remarks>
+    public ReadOnlySeString( ReadOnlySpan< byte > data ) => Data = data.ToArray();
+
+    /// <inheritdoc cref="ReadOnlySeString(ReadOnlySpan{byte})"/>
+    public ReadOnlySeString( Span< byte > data ) => Data = data.ToArray();
+
+    /// <summary>Initializes a new instance of the <see cref="ReadOnlySeString"/> struct.</summary>
     /// <param name="data">Raw SeString data.</param>
     /// <remarks>No further mutations to the underlying data behind <paramref name="data"/> is expected.</remarks>
     public ReadOnlySeString( ReadOnlyMemory< byte > data ) => Data = data;
+
+    /// <inheritdoc cref="ReadOnlySeString(ReadOnlyMemory{byte})"/>
+    public ReadOnlySeString( Memory< byte > data ) => Data = data;
+
+    /// <inheritdoc cref="ReadOnlySeString(ReadOnlyMemory{byte})"/>
+    public ReadOnlySeString( byte[] data ) => Data = data;
+
+    /// <summary>Initializes a new instance of the <see cref="ReadOnlySeString"/> struct.</summary>
+    /// <param name="data">Raw UTF-16 string data to copy from.</param>
+    /// <remarks>Data is copied from <paramref name="data"/>; this function is not allocation-free.</remarks>
+    public ReadOnlySeString( ReadOnlySpan< char > data )
+    {
+        if( data.IndexOfAny( (char) Stx, (char) Etx ) != -1 )
+            throw new ArgumentException( "STX and ETX cannot be contained in the string.", nameof( data ) );
+        var d = new byte[Encoding.UTF8.GetByteCount( data )];
+        Encoding.UTF8.GetBytes( data, d );
+        Data = d;
+    }
+
+    /// <inheritdoc cref="ReadOnlySeString(ReadOnlySpan{char})"/>
+    public ReadOnlySeString( Span< char > data ) : this( (ReadOnlySpan< char >) data )
+    { }
+
+    /// <inheritdoc cref="ReadOnlySeString(ReadOnlySpan{char})"/>
+    public ReadOnlySeString( ReadOnlyMemory< char > data ) : this( data.Span )
+    { }
+
+    /// <inheritdoc cref="ReadOnlySeString(ReadOnlySpan{char})"/>
+    public ReadOnlySeString( Memory< char > data ) : this( data.Span )
+    { }
+
+    /// <inheritdoc cref="ReadOnlySeString(ReadOnlySpan{char})"/>
+    public ReadOnlySeString( char[] data ) : this( data.AsSpan() )
+    { }
+
+    /// <inheritdoc cref="ReadOnlySeString(ReadOnlySpan{char})"/>
+    public ReadOnlySeString( string? data ) : this( data.AsSpan() )
+    { }
 
     /// <summary>Gets a value indicating whether this <see cref="ReadOnlySeString"/> is empty.</summary>
     public bool IsEmpty {
@@ -94,12 +140,68 @@ public readonly struct ReadOnlySeString : IEquatable< ReadOnlySeString >, IReadO
     [MethodImpl( MethodImplOptions.AggressiveInlining )]
     public static implicit operator ReadOnlySeString( Memory< byte > s ) => new( s );
 
+    /// <summary>Creates a new instance of <see cref="ReadOnlySeString"/> struct from the given byte span view.</summary>
+    /// <param name="s">The source byte span view.</param>
+    /// <returns>A new instance of <see cref="ReadOnlySeString"/> with <paramref name="s"/>.</returns>
+    /// <remarks>Data of <paramref name="s"/> is copied; this function is not allocation-free.</remarks>
+    [MethodImpl( MethodImplOptions.AggressiveInlining )]
+    public static implicit operator ReadOnlySeString( ReadOnlySpan< byte > s ) => new( s );
+
+    /// <summary>Creates a new instance of <see cref="ReadOnlySeString"/> struct from the given byte span view.</summary>
+    /// <param name="s">The source byte span view.</param>
+    /// <returns>A new instance of <see cref="ReadOnlySeString"/> with <paramref name="s"/>.</returns>
+    /// <remarks>Data of <paramref name="s"/> is copied; this function is not allocation-free.</remarks>
+    [MethodImpl( MethodImplOptions.AggressiveInlining )]
+    public static implicit operator ReadOnlySeString( Span< byte > s ) => new( s );
+
     /// <summary>Creates a new instance of <see cref="ReadOnlySeString"/> struct from the given byte array.</summary>
     /// <param name="s">The source byte array.</param>
     /// <returns>A new instance of <see cref="ReadOnlySeString"/> wrapping <paramref name="s"/>.</returns>
     /// <remarks><paramref name="s"/> is not expected to be mutated once the cast is done.</remarks>
     [MethodImpl( MethodImplOptions.AggressiveInlining )]
     public static implicit operator ReadOnlySeString( byte[] s ) => new( s );
+
+    /// <summary>Creates a new instance of <see cref="ReadOnlySeString"/> struct from the given char memory view.</summary>
+    /// <param name="s">The source char memory view.</param>
+    /// <returns>A new instance of <see cref="ReadOnlySeString"/> with <paramref name="s"/> encoded in UTF-8.</returns>
+    /// <remarks>Data of <paramref name="s"/> is copied; this function is not allocation-free.</remarks>
+    [MethodImpl( MethodImplOptions.AggressiveInlining )]
+    public static implicit operator ReadOnlySeString( ReadOnlyMemory< char > s ) => new( s );
+
+    /// <summary>Creates a new instance of <see cref="ReadOnlySeString"/> struct from the given char memory view.</summary>
+    /// <param name="s">The source char memory view.</param>
+    /// <returns>A new instance of <see cref="ReadOnlySeString"/> with <paramref name="s"/> encoded in UTF-8.</returns>
+    /// <remarks>Data of <paramref name="s"/> is copied; this function is not allocation-free.</remarks>
+    [MethodImpl( MethodImplOptions.AggressiveInlining )]
+    public static implicit operator ReadOnlySeString( Memory< char > s ) => new( s );
+
+    /// <summary>Creates a new instance of <see cref="ReadOnlySeString"/> struct from the given char span view.</summary>
+    /// <param name="s">The source char span view.</param>
+    /// <returns>A new instance of <see cref="ReadOnlySeString"/> with <paramref name="s"/> encoded in UTF-8.</returns>
+    /// <remarks>Data of <paramref name="s"/> is copied; this function is not allocation-free.</remarks>
+    [MethodImpl( MethodImplOptions.AggressiveInlining )]
+    public static implicit operator ReadOnlySeString( ReadOnlySpan< char > s ) => new( s );
+
+    /// <summary>Creates a new instance of <see cref="ReadOnlySeString"/> struct from the given char span view.</summary>
+    /// <param name="s">The source char span view.</param>
+    /// <returns>A new instance of <see cref="ReadOnlySeString"/> with <paramref name="s"/> encoded in UTF-8.</returns>
+    /// <remarks>Data of <paramref name="s"/> is copied; this function is not allocation-free.</remarks>
+    [MethodImpl( MethodImplOptions.AggressiveInlining )]
+    public static implicit operator ReadOnlySeString( Span< char > s ) => new( s );
+
+    /// <summary>Creates a new instance of <see cref="ReadOnlySeString"/> struct from the given char array.</summary>
+    /// <param name="s">The source char array.</param>
+    /// <returns>A new instance of <see cref="ReadOnlySeString"/> with <paramref name="s"/> encoded in UTF-8.</returns>
+    /// <remarks>Data of <paramref name="s"/> is copied; this function is not allocation-free.</remarks>
+    [MethodImpl( MethodImplOptions.AggressiveInlining )]
+    public static implicit operator ReadOnlySeString( char[] s ) => new( s );
+
+    /// <summary>Creates a new instance of <see cref="ReadOnlySeString"/> struct from the given char array.</summary>
+    /// <param name="s">The source char array.</param>
+    /// <returns>A new instance of <see cref="ReadOnlySeString"/> with <paramref name="s"/> encoded in UTF-8.</returns>
+    /// <remarks>Data of <paramref name="s"/> is copied; this function is not allocation-free.</remarks>
+    [MethodImpl( MethodImplOptions.AggressiveInlining )]
+    public static implicit operator ReadOnlySeString( string? s ) => new( s );
 
     /// <summary>Returns a value that indicates whether the specified strings are equal.</summary>
     /// <param name="left">The first string to compare.</param>
@@ -152,6 +254,21 @@ public readonly struct ReadOnlySeString : IEquatable< ReadOnlySeString >, IReadO
         right.Data.CopyTo( res.AsMemory( lnb ) );
         return new( res );
     }
+
+    /// <summary>Creates a new instance of the <see cref="ReadOnlySeString"/> struct from the given text in UTF-8.</summary>
+    /// <param name="text">Text to create a new <see cref="ReadOnlySeString"/> from.</param>
+    /// <returns>A new instance of <see cref="ReadOnlySeString"/>, independent of the backing memory of <paramref name="text"/>.</returns>
+    public static ReadOnlySeString FromText( ReadOnlySpan< byte > text )
+    {
+        if( text.IndexOfAny( Stx, Etx ) != -1 )
+            throw new ArgumentException( "STX and ETX cannot be contained in the string.", nameof( text ) );
+        return new( text );
+    }
+
+    /// <summary>Creates a new instance of the <see cref="ReadOnlySeString"/> struct from the given text in UTF-16.</summary>
+    /// <param name="text">Text to create a new <see cref="ReadOnlySeString"/> from.</param>
+    /// <returns>A new instance of <see cref="ReadOnlySeString"/>, independent of the backing memory of <paramref name="text"/>.</returns>
+    public static ReadOnlySeString FromText( ReadOnlySpan< char > text ) => new( text );
 
     /// <summary>Gets a <see cref="ReadOnlySeStringSpan"/> from this <see cref="ReadOnlySeString"/>.</summary>
     /// <returns>A new instance of <see cref="ReadOnlySeStringSpan"/>.</returns>

--- a/src/Lumina/Text/ReadOnly/ReadOnlySeStringSpan.cs
+++ b/src/Lumina/Text/ReadOnly/ReadOnlySeStringSpan.cs
@@ -304,9 +304,18 @@ public readonly ref struct ReadOnlySeStringSpan
     public override string ToString()
     {
         var sb = new StringBuilder();
-        foreach( var v in this )
-            sb.Append( v.ToString() );
+        AppendMacroStringToStringBuilder( sb, false );
         return sb.ToString();
+    }
+
+    /// <summary>Writes the encodeable macro representation of this instance of <see cref="ReadOnlySeStringSpan"/> to the given string builder.</summary>
+    /// <param name="sb">Target string builder.</param>
+    /// <param name="forStringExpression">Whether this is being encoded to be used as a string expression.</param>
+    /// <returns>The encodeable macro representation.</returns>
+    public void AppendMacroStringToStringBuilder( StringBuilder sb, bool forStringExpression )
+    {
+        foreach( var v in this )
+            v.AppendMacroStringToStringBuilder( sb, forStringExpression );
     }
 
     /// <inheritdoc cref="IEnumerable{T}.GetEnumerator"/>

--- a/src/Lumina/Text/SeString.cs
+++ b/src/Lumina/Text/SeString.cs
@@ -187,5 +187,11 @@ namespace Lumina.Text
         {
             return string.Concat( Payloads );
         }
+
+        internal void AppendMacroStringToStringBuilder( StringBuilder sb, bool forStringExpression )
+        {
+            foreach( var p in Payloads )
+                p.AppendMacroStringToStringBuilder( sb, forStringExpression );
+        }
     }
 }

--- a/src/Lumina/Text/SeStringBuilder.Append.cs
+++ b/src/Lumina/Text/SeStringBuilder.Append.cs
@@ -3,7 +3,9 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
+using Lumina.Text.Parse;
 using Lumina.Text.ReadOnly;
 
 namespace Lumina.Text;
@@ -245,6 +247,34 @@ public sealed partial class SeStringBuilder
     /// <param name="value">Value to add.</param>
     /// <returns>A reference of this instance after the append operation is completed.</returns>
     public SeStringBuilder Append( object? value ) => Append( value?.ToString() );
+
+    /// <summary>Adds the given value after parsing it as a macro string.</summary>
+    /// <param name="value">String to parse and add.</param>
+    /// <param name="flags">Parse flags for <see cref="value"/>.</param>
+    /// <param name="exceptionMode">Action to take on parse failure.</param>
+    /// <returns>A reference of this instance after the append operation is completed.</returns>
+    public SeStringBuilder AppendMacroString(
+        ReadOnlySpan< byte > value,
+        UtfEnumeratorFlags flags = default,
+        MacroStringParseExceptionMode exceptionMode = MacroStringParseExceptionMode.Throw )
+    {
+        new MacroStringParser( value, flags, this, exceptionMode ).ParseMacroStringAndAppend( 0, false, default );
+        return this;
+    }
+
+    /// <summary>Adds the given value after parsing it as a macro string.</summary>
+    /// <param name="value">String to parse and add.</param>
+    /// <param name="flags">Parse flags for <see cref="value"/>.</param>
+    /// <param name="exceptionMode">Action to take on parse failure.</param>
+    /// <returns>A reference of this instance after the append operation is completed.</returns>
+    public SeStringBuilder AppendMacroString(
+        ReadOnlySpan< char > value,
+        UtfEnumeratorFlags flags = default,
+        MacroStringParseExceptionMode exceptionMode = MacroStringParseExceptionMode.Throw ) =>
+        AppendMacroString(
+            MemoryMarshal.Cast< char, byte >( value ),
+            (flags & UtfEnumeratorFlags.UtfMask) == UtfEnumeratorFlags.Default ? UtfEnumeratorFlags.Utf16 | flags : flags,
+            exceptionMode );
 
     /// <summary>Adds the given value.</summary>
     /// <param name="value">Value to add.</param>

--- a/src/Lumina/Text/SeStringBuilder.Append.cs
+++ b/src/Lumina/Text/SeStringBuilder.Append.cs
@@ -250,7 +250,7 @@ public sealed partial class SeStringBuilder
 
     /// <summary>Adds the given value after parsing it as a macro string.</summary>
     /// <param name="value">String to parse and add.</param>
-    /// <param name="flags">Parse flags for <see cref="value"/>.</param>
+    /// <param name="flags">Parse flags for <paramref cref="value"/>.</param>
     /// <param name="exceptionMode">Action to take on parse failure.</param>
     /// <returns>A reference of this instance after the append operation is completed.</returns>
     public SeStringBuilder AppendMacroString(
@@ -264,7 +264,7 @@ public sealed partial class SeStringBuilder
 
     /// <summary>Adds the given value after parsing it as a macro string.</summary>
     /// <param name="value">String to parse and add.</param>
-    /// <param name="flags">Parse flags for <see cref="value"/>.</param>
+    /// <param name="flags">Parse flags for <paramref cref="value"/>.</param>
     /// <param name="exceptionMode">Action to take on parse failure.</param>
     /// <returns>A reference of this instance after the append operation is completed.</returns>
     public SeStringBuilder AppendMacroString(

--- a/src/Lumina/Text/SeStringBuilder.AppendLine.cs
+++ b/src/Lumina/Text/SeStringBuilder.AppendLine.cs
@@ -1,6 +1,7 @@
 using Lumina.Text.ReadOnly;
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Lumina.Text;
@@ -53,6 +54,28 @@ public sealed partial class SeStringBuilder
     /// <returns>A reference of this instance after the append operation is completed.</returns>
     public SeStringBuilder AppendLine( string? value, int startIndex, int count )
         => AppendLine( value.AsSpan( startIndex, count ) );
+
+    /// <summary>Adds the specified interpolated string.</summary>
+    /// <param name="handler">Interpolated string to append.</param>
+    /// <returns>A reference of this instance after the append operation is completed.</returns>
+    public SeStringBuilder AppendLine( [InterpolatedStringHandlerArgument( "" )] SeStringInterpolatedStringHandler handler )
+    {
+        _ = handler;
+        return AppendNewLine();
+    }
+
+    /// <summary>Adds the specified interpolated string.</summary>
+    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+    /// <param name="handler">Interpolated string to append.</param>
+    /// <returns>A reference of this instance after the append operation is completed.</returns>
+    public SeStringBuilder AppendLine(
+        IFormatProvider? provider,
+        [InterpolatedStringHandlerArgument( "", "provider" )]
+        SeStringInterpolatedStringHandler handler )
+    {
+        _ = handler;
+        return AppendNewLine();
+    }
 
     /// <summary>Adds the given UTF-8 byte sequence and a line break.</summary>
     /// <param name="value">Text to add.</param>

--- a/src/Lumina/Text/SeStringBuilder.AppendTypedElement.cs
+++ b/src/Lumina/Text/SeStringBuilder.AppendTypedElement.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Lumina.Text;
+
+public sealed partial class SeStringBuilder
+{
+    /// <summary>Adds the given character.</summary>
+    /// <param name="rune">Character to add.</param>
+    /// <returns>A reference of this instance after the append operation is completed.</returns>
+    public SeStringBuilder Append( Rune rune )
+    {
+        rune.EncodeToUtf8( AllocateStringSpan( rune.Utf8SequenceLength ) );
+        return this;
+    }
+
+    /// <summary>Adds the given character.</summary>
+    /// <param name="rune">Character to add.</param>
+    /// <param name="repeatCount">Number of times to append <paramref name="rune"/>.</param>
+    /// <returns>A reference of this instance after the append operation is completed.</returns>
+    public SeStringBuilder Append( Rune rune, int repeatCount )
+    {
+        if( repeatCount == 0 )
+            return this;
+
+        if( repeatCount < 0 )
+            throw new ArgumentOutOfRangeException( nameof( repeatCount ), repeatCount, null );
+
+        var span = AllocateStringSpan( rune.Utf8SequenceLength * repeatCount );
+        var sequence = span[ ..rune.EncodeToUtf8( span ) ];
+        span = span[ sequence.Length.. ];
+        while( !span.IsEmpty )
+        {
+            sequence.CopyTo( span );
+            span = span[ sequence.Length.. ];
+        }
+
+        return this;
+    }
+
+    /// <summary>Adds the given <see cref="Rune"/>, or <see cref="Rune.ReplacementChar"/> if the value is not valid.</summary>
+    /// <param name="utfValue">Character to add.</param>
+    /// <returns>A reference of this instance after the append operation is completed.</returns>
+    public SeStringBuilder Append( UtfValue utfValue ) => AppendChar( utfValue.IntValue );
+
+    /// <summary>Adds the given character.</summary>
+    /// <param name="subsequence">Character to add.</param>
+    /// <returns>A reference of this instance after the append operation is completed.</returns>
+    public SeStringBuilder Append( scoped in UtfEnumerator.Subsequence subsequence ) => Append( subsequence.EffectiveRune );
+
+    #region I/Utf8/SpanFormattable
+
+    /// <summary>Adds the string representation of a <paramref name="value"/> to this instance.</summary>
+    /// <param name="value">Value to add.</param>
+    /// <returns>A reference to this instance after the append operation has completed.</returns>
+    public SeStringBuilder Append( bool value ) => Append( value ? "true"u8 : "false"u8 );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( char value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( byte value ) => AppendChar( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( ushort value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( uint value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( ulong value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( nuint value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( sbyte value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( short value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( int value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( long value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( nint value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public unsafe SeStringBuilder Append( void* value ) => Append( (nint) value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( Half value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( float value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( double value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( scoped in decimal value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( scoped in System.Numerics.BigInteger value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( DateOnly value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( TimeOnly value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( TimeSpan value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( DateTime value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( DateTimeOffset value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( scoped in Version value ) => AppendSpanFormattableAuto( value );
+
+#if NET7_0_OR_GREATER
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( scoped in System.Numerics.Complex value ) => AppendSpanFormattableAuto( value );
+#endif
+
+#if NET8_0_OR_GREATER
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( scoped in UInt128 value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( scoped in Int128 value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( System.Net.IPAddress value ) => AppendSpanFormattableAuto( value );
+
+    /// <inheritdoc cref="Append(bool)" />
+    public SeStringBuilder Append( System.Net.IPNetwork value ) => AppendSpanFormattableAuto( value );
+#endif
+
+    #endregion
+
+    /// <summary>Adds the given value.</summary>
+    /// <param name="value">Value to add.</param>
+    /// <returns>A reference of this instance after the append operation is completed.</returns>
+    public SeStringBuilder Append( object? value ) => Append( value?.ToString() );
+
+    /// <summary>Adds the given value.</summary>
+    /// <param name="value">Value to add.</param>
+    /// <returns>A reference of this instance after the append operation is completed.</returns>
+    public SeStringBuilder Append< T >( scoped in T value ) => value switch
+    {
+#if NET8_0_OR_GREATER
+        IUtf8SpanFormattable f => AppendSpanFormattableUtf8( f ),
+#endif
+        ISpanFormattable f => AppendSpanFormattableUtf16( f ),
+        null => Append( "null"u8 ),
+        _ => Append( value.ToString() )
+    };
+
+#if NET8_0_OR_GREATER
+    /// <summary>Helper method for <see cref="Append{T}"/>.</summary>
+    /// <param name="value">The value to append.</param>
+    /// <typeparam name="T">The span formattable type.</typeparam>
+    /// <returns>A reference of this instance after the append operation is completed.</returns>
+    [MethodImpl( MethodImplOptions.AggressiveInlining )]
+    private SeStringBuilder AppendSpanFormattableUtf8< T >( scoped in T value ) where T : IUtf8SpanFormattable
+    {
+        var span = Span< byte >.Empty;
+        for( var len = Unsafe.SizeOf< MemoryChunkStorage >(); len < Array.MaxLength >> 1; len *= 2 )
+        {
+            span = ReallocateStringSpan( span.Length, len );
+            if( value.TryFormat( span, out var written, default, null ) )
+            {
+                ReallocateStringSpan( span.Length, written );
+                return this;
+            }
+        }
+
+        throw new OutOfMemoryException();
+    }
+#endif
+
+    /// <summary>Helper method for <see cref="Append{T}"/>.</summary>
+    /// <param name="value">The value to append.</param>
+    /// <typeparam name="T">The span formattable type.</typeparam>
+    /// <returns>A reference of this instance after the append operation is completed.</returns>
+    [MethodImpl( MethodImplOptions.AggressiveInlining )]
+    private SeStringBuilder AppendSpanFormattableUtf16< T >( scoped in T value ) where T : ISpanFormattable
+    {
+        var span = MemoryChunkStorage.AsSpanUninitialized< char >( out _ );
+        if( value.TryFormat( span, out var written, default, null ) )
+        {
+            Append( span[ ..written ] );
+            return this;
+        }
+
+        for( var len = 2 * Unsafe.SizeOf< MemoryChunkStorage >(); len < Array.MaxLength >> 2; len *= 2 )
+        {
+            var buf = ArrayPool< char >.Shared.Rent( len );
+            if( value.TryFormat( buf, out written, default, null ) )
+            {
+                Append( buf[ ..written ] );
+                ArrayPool< char >.Shared.Return( buf );
+                return this;
+            }
+
+            ArrayPool< char >.Shared.Return( buf );
+        }
+
+        throw new OutOfMemoryException();
+    }
+
+    /// <summary>Helper method for <see cref="Append{T}"/>.</summary>
+    /// <param name="value">The value to append.</param>
+    /// <typeparam name="T">The span formattable type.</typeparam>
+    /// <returns>A reference of this instance after the append operation is completed.</returns>
+#if NET8_0_OR_GREATER
+    [MethodImpl( MethodImplOptions.AggressiveInlining )]
+    private SeStringBuilder AppendSpanFormattableAuto< T >( T value ) where T : IUtf8SpanFormattable => AppendSpanFormattableUtf8( value );
+#else
+    [MethodImpl( MethodImplOptions.AggressiveInlining )]
+    private SeStringBuilder AppendSpanFormattableAuto< T >( T value ) where T : ISpanFormattable => AppendSpanFormattableUtf16( value );
+#endif
+
+    /// <summary>Dummy struct for reserving a chunk of memory in stack at compile-time the bat without having to stackalloc.</summary>
+    [StructLayout( LayoutKind.Explicit, Size = 256, Pack = 1 )]
+    private struct MemoryChunkStorage
+    {
+        /// <summary>Reinterprets a reference of <see cref="MemoryChunkStorage"/> as a <see cref="Span{T}"/> of <typeparamref name="T"/> without zero-initializing.
+        /// </summary>
+        /// <param name="storage">Backing storage.</param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        [MethodImpl( MethodImplOptions.AggressiveInlining )]
+        [SuppressMessage( "ReSharper", "OutParameterValueIsAlwaysDiscarded.Local", Justification = "Stack reservation" )]
+        public static Span< T > AsSpanUninitialized< T >( out MemoryChunkStorage storage ) where T : struct
+        {
+            Unsafe.SkipInit( out storage );
+            return MemoryMarshal.Cast< MemoryChunkStorage, T >( MemoryMarshal.CreateSpan( ref storage, 1 ) );
+        }
+    }
+}

--- a/src/Lumina/Text/SeStringBuilder.AppendTypedElement.cs
+++ b/src/Lumina/Text/SeStringBuilder.AppendTypedElement.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Buffers;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text;
+using Lumina.Misc;
 
 namespace Lumina.Text;
 
@@ -231,22 +230,4 @@ public sealed partial class SeStringBuilder
     [MethodImpl( MethodImplOptions.AggressiveInlining )]
     private SeStringBuilder AppendSpanFormattableAuto< T >( T value ) where T : ISpanFormattable => AppendSpanFormattableUtf16( value );
 #endif
-
-    /// <summary>Dummy struct for reserving a chunk of memory in stack at compile-time the bat without having to stackalloc.</summary>
-    [StructLayout( LayoutKind.Explicit, Size = 256, Pack = 1 )]
-    private struct MemoryChunkStorage
-    {
-        /// <summary>Reinterprets a reference of <see cref="MemoryChunkStorage"/> as a <see cref="Span{T}"/> of <typeparamref name="T"/> without zero-initializing.
-        /// </summary>
-        /// <param name="storage">Backing storage.</param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        [MethodImpl( MethodImplOptions.AggressiveInlining )]
-        [SuppressMessage( "ReSharper", "OutParameterValueIsAlwaysDiscarded.Local", Justification = "Stack reservation" )]
-        public static Span< T > AsSpanUninitialized< T >( out MemoryChunkStorage storage ) where T : struct
-        {
-            Unsafe.SkipInit( out storage );
-            return MemoryMarshal.Cast< MemoryChunkStorage, T >( MemoryMarshal.CreateSpan( ref storage, 1 ) );
-        }
-    }
 }

--- a/src/Lumina/Text/SeStringBuilder.Expressions.cs
+++ b/src/Lumina/Text/SeStringBuilder.Expressions.cs
@@ -165,21 +165,8 @@ public sealed partial class SeStringBuilder
     /// <returns>A reference of this instance after the operation is completed.</returns>
     public SeStringBuilder AbortExpression()
     {
-        switch( _mss[ ^1 ].Type )
-        {
-            case StackType.String:
-                if( _mss.Count == 1 || _mss[ ^1 ].Type != StackType.String )
-                    throw new InvalidOperationException( "String expression is not currently being built." );
-                break;
-
-            case StackType.Expression:
-                if( _mss[ ^1 ].Ident != 0 )
-                    throw new InvalidOperationException( $"{_mss[ ^1 ].Ident} more expression(s) must be written." );
-                break;
-
-            default:
-                throw new InvalidOperationException( "No expression is being written." );
-        }
+        if( _mss[ ^1 ].Type is not (StackType.String or StackType.Expression) )
+            throw new InvalidOperationException( "No expression is being written." );
 
         var stream = _mss[ ^1 ].Stream;
         _mss.RemoveAt( _mss.Count - 1 );

--- a/src/Lumina/Text/SeStringBuilder.Expressions.cs
+++ b/src/Lumina/Text/SeStringBuilder.Expressions.cs
@@ -92,7 +92,7 @@ public sealed partial class SeStringBuilder
     /// <returns>A reference of this instance after the operation is completed.</returns>
     public SeStringBuilder ChangeBinaryExpression( ExpressionType expressionType )
     {
-        if( _mss[ ^1 ].Type is not StackType.Expression || ((ExpressionType)_mss[^1].Stream.GetBuffer()[0]).GetArity() != ExpressionArity.Binary)
+        if( _mss[ ^1 ].Type is not StackType.Expression || ( (ExpressionType) _mss[ ^1 ].Stream.GetBuffer()[ 0 ] ).GetArity() != ExpressionArity.Binary )
             throw new InvalidOperationException( "Current scope is not a binary expression." );
         if( expressionType.GetArity() != ExpressionArity.Binary )
             throw new ArgumentOutOfRangeException( nameof( expressionType ), expressionType, "Only binary expression types are allowed." );

--- a/src/Lumina/Text/SeStringBuilder.InterpolatedStringHandler.cs
+++ b/src/Lumina/Text/SeStringBuilder.InterpolatedStringHandler.cs
@@ -1,0 +1,784 @@
+using System;
+using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Lumina.Text.ReadOnly;
+
+namespace Lumina.Text;
+
+public sealed partial class SeStringBuilder
+{
+    /// <summary>Interpolation handler for <see cref="SeStringBuilder"/>.</summary>
+    [InterpolatedStringHandler]
+    public readonly ref struct SeStringInterpolatedStringHandler
+    {
+        private readonly SeStringBuilder _builder;
+        private readonly IFormatProvider? _provider;
+
+        /// <summary>Initializes a new instance of the <see cref="SeStringInterpolatedStringHandler"/> struct.</summary>
+        /// <param name="literalLength">Number of characters in the literal.</param>
+        /// <param name="formattedCount">Number of formatted entries.</param>
+        /// <param name="builder">Instance of <see cref="SeStringBuilder"/> to append to.</param>
+        [MethodImpl( MethodImplOptions.AggressiveInlining )]
+        [SuppressMessage( "ReSharper", "IntroduceOptionalParameters.Global", Justification = "InterpolatedStringHandlerArgument" )]
+        public SeStringInterpolatedStringHandler( int literalLength, int formattedCount, SeStringBuilder builder )
+            : this( literalLength, formattedCount, builder, null )
+        { }
+
+        /// <summary>Initializes a new instance of the <see cref="SeStringInterpolatedStringHandler"/> struct.</summary>
+        /// <param name="literalLength">Number of characters in the literal.</param>
+        /// <param name="formattedCount">Number of formatted entries.</param>
+        /// <param name="builder">Instance of <see cref="SeStringBuilder"/> to append to.</param>
+        /// <param name="provider">Format provider.</param>
+        [MethodImpl( MethodImplOptions.AggressiveInlining )]
+        public SeStringInterpolatedStringHandler( int literalLength, int formattedCount, SeStringBuilder builder, IFormatProvider? provider )
+        {
+            _builder = builder;
+            _provider = provider;
+            _ = formattedCount;
+
+            builder.ReallocateStringSpan( builder.AllocateStringSpan( literalLength * 4 ).Length, 0 );
+        }
+
+        /// <summary>Writes the specified string to the handler.</summary>
+        /// <param name="value">The string to write.</param>
+        public void AppendLiteral( string value ) => _builder.Append( value );
+
+        /// <summary>Writes the specified value to the handler.</summary>
+        /// <param name="value">The value to write.</param>
+        /// <typeparam name="T">The type of the value to write.</typeparam>
+        public void AppendFormatted< T >( T value ) => AppendFormatted( value, 0, null );
+
+        /// <summary>Writes the specified value to the handler.</summary>
+        /// <param name="value">The value to write.</param>
+        /// <param name="format">The format string.</param>
+        /// <typeparam name="T">The type of the value to write.</typeparam>
+        public void AppendFormatted< T >( T value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <summary>Writes the specified value to the handler.</summary>
+        /// <param name="value">The value to write.</param>
+        /// <param name="alignment">The minimum number of characters that should be written for this value. If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+        /// <typeparam name="T">The type of the value to write.</typeparam>
+        public void AppendFormatted< T >( T value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <summary>Writes the specified value to the handler.</summary>
+        /// <param name="value">The value to write.</param>
+        /// <param name="alignment">The minimum number of characters that should be written for this value. If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+        /// <param name="format">The format string.</param>
+        /// <typeparam name="T">The type of the value to write.</typeparam>
+        public void AppendFormatted< T >( T value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            switch( value )
+            {
+#if NET8_0_OR_GREATER
+                case IUtf8SpanFormattable f:
+                    AppendSpanFormattableUtf8( f, format );
+                    break;
+#endif
+                case ISpanFormattable f:
+                    AppendSpanFormattableUtf16( f, format );
+                    break;
+                case IFormattable f:
+                    _builder.Append( f.ToString( format, _provider ) );
+                    break;
+                case null:
+                    _builder.Append( "null"u8 );
+                    break;
+                default:
+                    _builder.Append( value.ToString() );
+                    break;
+            }
+
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( bool value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( bool value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( bool value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( bool value, int alignment, string? format )
+        {
+            _ = format;
+            var prevLen = _builder.GetStringStream().Length;
+            _builder.Append( value ? "true"u8 : "false"u8 );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( char value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( char value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( char value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( char value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( byte value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( byte value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( byte value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( byte value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( ushort value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( ushort value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( ushort value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( ushort value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( uint value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( uint value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( uint value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( uint value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( ulong value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( ulong value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( ulong value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( ulong value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( nuint value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( nuint value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( nuint value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( nuint value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( sbyte value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( sbyte value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( sbyte value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( sbyte value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( short value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( short value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( short value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( short value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( int value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( int value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( int value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( int value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( long value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( long value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( long value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( long value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( nint value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( nint value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( nint value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( nint value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public unsafe void AppendFormatted( void* value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public unsafe void AppendFormatted( void* value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public unsafe void AppendFormatted( void* value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public unsafe void AppendFormatted( void* value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( (nint) value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( Half value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( Half value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( Half value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( Half value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( float value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( float value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( float value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( float value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( double value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( double value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( double value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( double value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( scoped in decimal value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( scoped in decimal value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( scoped in decimal value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( scoped in decimal value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( scoped in System.Numerics.BigInteger value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( scoped in System.Numerics.BigInteger value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( scoped in System.Numerics.BigInteger value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( scoped in System.Numerics.BigInteger value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( DateOnly value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( DateOnly value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( DateOnly value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( DateOnly value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( TimeOnly value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( TimeOnly value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( TimeOnly value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( TimeOnly value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( TimeSpan value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( TimeSpan value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( TimeSpan value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( TimeSpan value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( DateTime value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( DateTime value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( DateTime value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( DateTime value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( DateTimeOffset value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( DateTimeOffset value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( DateTimeOffset value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( DateTimeOffset value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+#if NET7_0_OR_GREATER
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( scoped in System.Numerics.Complex value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( scoped in System.Numerics.Complex value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( scoped in System.Numerics.Complex value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( scoped in System.Numerics.Complex value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+#endif
+
+#if NET8_0_OR_GREATER
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( scoped in UInt128 value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( scoped in UInt128 value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( scoped in UInt128 value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( scoped in UInt128 value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( scoped in Int128 value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( scoped in Int128 value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( scoped in Int128 value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( scoped in Int128 value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( System.Net.IPAddress value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( System.Net.IPAddress value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( System.Net.IPAddress value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( System.Net.IPAddress value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( System.Net.IPNetwork value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( System.Net.IPNetwork value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( System.Net.IPNetwork value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( System.Net.IPNetwork value, int alignment, string? format )
+        {
+            var prevLen = _builder.GetStringStream().Length;
+            AppendSpanFormattableAuto( value, format );
+            FixAlignment( prevLen, alignment );
+        }
+#endif
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( ReadOnlySpan< byte > value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( ReadOnlySpan< byte > value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( ReadOnlySpan< byte > value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( ReadOnlySpan< byte > value, int alignment, string? format )
+        {
+            _ = format;
+            var prevLen = _builder.GetStringStream().Length;
+            _builder.Append( value );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( ReadOnlySeString value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( ReadOnlySeString value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( ReadOnlySeString value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( ReadOnlySeString value, int alignment, string? format )
+        {
+            _ = format;
+            var prevLen = _builder.GetStringStream().Length;
+            _builder.Append( value );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( ReadOnlySeStringSpan value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( ReadOnlySeStringSpan value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( ReadOnlySeStringSpan value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( ReadOnlySeStringSpan value, int alignment, string? format )
+        {
+            _ = format;
+            var prevLen = _builder.GetStringStream().Length;
+            _builder.Append( value );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( ReadOnlySePayload value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( ReadOnlySePayload value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( ReadOnlySePayload value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( ReadOnlySePayload value, int alignment, string? format )
+        {
+            _ = format;
+            var prevLen = _builder.GetStringStream().Length;
+            _builder.Append( value );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( ReadOnlySePayloadSpan value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( ReadOnlySePayloadSpan value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( ReadOnlySePayloadSpan value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( ReadOnlySePayloadSpan value, int alignment, string? format )
+        {
+            _ = format;
+            var prevLen = _builder.GetStringStream().Length;
+            _builder.Append( value );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( SeString value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( SeString value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( SeString value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( SeString value, int alignment, string? format )
+        {
+            _ = format;
+            var prevLen = _builder.GetStringStream().Length;
+            _builder.Append( value );
+            FixAlignment( prevLen, alignment );
+        }
+
+        /// <inheritdoc cref="AppendFormatted{T}(T)"/>
+        public void AppendFormatted( ReadOnlySpan< char > value ) => AppendFormatted( value, 0, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted( ReadOnlySpan< char > value, string? format ) => AppendFormatted( value, 0, format );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted( ReadOnlySpan< char > value, int alignment ) => AppendFormatted( value, alignment, null );
+
+        /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
+        public void AppendFormatted( ReadOnlySpan< char > value, int alignment, string? format )
+        {
+            _ = format;
+            var prevLen = _builder.GetStringStream().Length;
+            _builder.Append( value );
+            FixAlignment( prevLen, alignment );
+        }
+
+        private void FixAlignment( long prevLen, int alignment )
+        {
+            if( alignment == 0 )
+                return;
+
+            var len = (int) ( _builder.GetStringStream().Length - prevLen );
+            if( len <= -alignment || len >= alignment )
+                return;
+
+            if( alignment < 0 )
+            {
+                // left align
+                _builder.AllocateStringSpan( len + alignment ).Fill( (byte) ' ' );
+            }
+            else
+            {
+                // right align
+                var span = _builder.ReallocateStringSpan( len, alignment );
+                span[ ..len ].CopyTo( span[ ^len.. ] );
+                span[ ..^len ].Fill( (byte) ' ' );
+            }
+        }
+
+#if NET8_0_OR_GREATER
+        /// <inheritdoc cref="SeStringBuilder.AppendSpanFormattableUtf8{T}"/>
+        [MethodImpl( MethodImplOptions.AggressiveInlining )]
+        private void AppendSpanFormattableUtf8< T >( scoped in T value, ReadOnlySpan< char > format ) where T : IUtf8SpanFormattable
+        {
+            var span = Span< byte >.Empty;
+            for( var len = Unsafe.SizeOf< MemoryChunkStorage >(); len < Array.MaxLength >> 1; len *= 2 )
+            {
+                span = _builder.ReallocateStringSpan( span.Length, len );
+                if( value.TryFormat( span, out var written, format, _provider ) )
+                {
+                    _builder.ReallocateStringSpan( span.Length, written );
+                    return;
+                }
+            }
+
+            throw new OutOfMemoryException();
+        }
+#endif
+
+        /// <inheritdoc cref="SeStringBuilder.AppendSpanFormattableUtf16{T}"/>
+        [MethodImpl( MethodImplOptions.AggressiveInlining )]
+        private void AppendSpanFormattableUtf16< T >( scoped in T value, ReadOnlySpan< char > format ) where T : ISpanFormattable
+        {
+            var span = MemoryChunkStorage.AsSpanUninitialized< char >( out _ );
+            if( value.TryFormat( span, out var written, format, _provider ) )
+            {
+                _builder.Append( span[ ..written ] );
+                return;
+            }
+
+            for( var len = 2 * Unsafe.SizeOf< MemoryChunkStorage >(); len < Array.MaxLength >> 2; len *= 2 )
+            {
+                var buf = ArrayPool< char >.Shared.Rent( len );
+                if( value.TryFormat( buf, out written, format, _provider ) )
+                {
+                    _builder.Append( buf[ ..written ] );
+                    ArrayPool< char >.Shared.Return( buf );
+                    return;
+                }
+
+                ArrayPool< char >.Shared.Return( buf );
+            }
+
+            throw new OutOfMemoryException();
+        }
+
+        /// <inheritdoc cref="SeStringBuilder.AppendSpanFormattableAuto{T}"/>
+#if NET8_0_OR_GREATER
+        [MethodImpl( MethodImplOptions.AggressiveInlining )]
+        private void AppendSpanFormattableAuto< T >( T value, ReadOnlySpan< char > format ) where T : IUtf8SpanFormattable =>
+            AppendSpanFormattableUtf8( value, format );
+#else
+        [MethodImpl( MethodImplOptions.AggressiveInlining )]
+        private void AppendSpanFormattableAuto< T >( T value, ReadOnlySpan< char > format ) where T : ISpanFormattable =>
+            AppendSpanFormattableUtf16( value, format );
+#endif
+    }
+}

--- a/src/Lumina/Text/SeStringBuilder.InterpolatedStringHandler.cs
+++ b/src/Lumina/Text/SeStringBuilder.InterpolatedStringHandler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using Lumina.Misc;
 using Lumina.Text.ReadOnly;
 
 namespace Lumina.Text;

--- a/src/Lumina/Text/SeStringBuilder.cs
+++ b/src/Lumina/Text/SeStringBuilder.cs
@@ -70,7 +70,7 @@ public sealed partial class SeStringBuilder : IResettable
     public SeStringBuilder AbortMacro()
     {
         if( _mss[ ^1 ].Type != StackType.Payload )
-            throw new InvalidOperationException( "No payload is currently being built." );
+            throw new InvalidOperationException( "No payload is currently being built." + _mss[^1].Type );
 
         var stream = _mss[ ^1 ].Stream;
         _mss.RemoveAt( _mss.Count - 1 );

--- a/src/Lumina/Text/SeStringBuilder.cs
+++ b/src/Lumina/Text/SeStringBuilder.cs
@@ -65,6 +65,21 @@ public sealed partial class SeStringBuilder : IResettable
         return this;
     }
 
+    /// <summary>Aborts a macro build by discarding the current macro data and exiting the macro scope.</summary>
+    /// <returns>A reference of this instance after the operation is completed.</returns>
+    public SeStringBuilder AbortMacro()
+    {
+        if( _mss[ ^1 ].Type != StackType.Payload )
+            throw new InvalidOperationException( "No payload is currently being built." );
+
+        var stream = _mss[ ^1 ].Stream;
+        _mss.RemoveAt( _mss.Count - 1 );
+        stream.SetLength( stream.Position = 0 );
+        _mssFree.Add( stream );
+
+        return this;
+    }
+
     /// <summary>Clears everything.</summary>
     /// <param name="zeroBuffer">Whether to fill the underlying buffer with zeroes.</param>
     /// <returns>A reference of this instance after the clear operation is completed.</returns>

--- a/src/Lumina/Text/UtfEnumerator.cs
+++ b/src/Lumina/Text/UtfEnumerator.cs
@@ -1,0 +1,334 @@
+using System;
+using System.Collections;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using Lumina.Text.Payloads;
+using Lumina.Text.ReadOnly;
+
+namespace Lumina.Text;
+
+/// <summary>Enumerates a UTF-N byte sequence by codepoint.</summary>
+[DebuggerDisplay("{Current}/{_data.Length} ({_flags}, BE={_isBigEndian})")]
+public ref struct UtfEnumerator
+{
+    private readonly ReadOnlySpan<byte> _data;
+    private readonly UtfEnumeratorFlags _flags;
+    private readonly byte _numBytesPerUnit;
+    private bool _isBigEndian;
+
+    /// <summary>Initializes a new instance of the <see cref="UtfEnumerator"/> struct.</summary>
+    /// <param name="data">UTF-N byte sequence.</param>
+    /// <param name="flags">Enumeration flags.</param>
+    public UtfEnumerator(ReadOnlySpan<byte> data, UtfEnumeratorFlags flags)
+    {
+        _data = data;
+        _flags = flags;
+        _numBytesPerUnit = (_flags & UtfEnumeratorFlags.UtfMask) switch
+        {
+            UtfEnumeratorFlags.Utf8 or UtfEnumeratorFlags.Utf8SeString => 1,
+            UtfEnumeratorFlags.Utf16 => 2,
+            UtfEnumeratorFlags.Utf32 => 4,
+            _ => throw new ArgumentOutOfRangeException(nameof(flags), flags, "Multiple UTF flag specified."),
+        };
+        _isBigEndian = (flags & UtfEnumeratorFlags.EndiannessMask) switch
+        {
+            UtfEnumeratorFlags.NativeEndian => !BitConverter.IsLittleEndian,
+            UtfEnumeratorFlags.LittleEndian => false,
+            UtfEnumeratorFlags.BigEndian => true,
+            _ => throw new ArgumentOutOfRangeException(nameof(flags), flags, "Multiple endianness flag specified."),
+        };
+    }
+
+    /// <inheritdoc cref="IEnumerator.Current"/>
+    public Subsequence Current { get; private set; } = default;
+
+    /// <summary>Creates a new instance of the <see cref="UtfEnumerator"/> struct.</summary>
+    /// <param name="data">UTF-N byte sequence.</param>
+    /// <param name="flags">Enumeration flags.</param>
+    /// <returns>A new enumerator.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static UtfEnumerator From(ReadOnlySpan<byte> data, UtfEnumeratorFlags flags) => new(data, flags);
+
+    /// <summary>Creates a new instance of the <see cref="UtfEnumerator"/> struct.</summary>
+    /// <param name="data">UTF-N byte sequence.</param>
+    /// <param name="flags">Enumeration flags.</param>
+    /// <returns>A new enumerator.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static UtfEnumerator From(ReadOnlySpan<char> data, UtfEnumeratorFlags flags) =>
+        new(MemoryMarshal.Cast<char, byte>(data), flags);
+
+    /// <summary>Gets the representative <c>char</c> for a given SeString macro code.</summary>
+    /// <param name="macroCode">The macro code.</param>
+    /// <returns>Representative <c>char</c>, or <see cref="char.MaxValue"/> if none.</returns>
+    public static char RepresentativeCharFor(MacroCode macroCode) => macroCode switch
+    {
+        MacroCode.NewLine => '\u0085',
+        MacroCode.SoftHyphen => '\u00AD',
+        MacroCode.NonBreakingSpace => '\u00A0',
+        MacroCode.Hyphen => '-',
+        MacroCode.Icon or MacroCode.Icon2 => '\uFFFC',
+        _ => char.MaxValue,
+    };
+
+    /// <summary>Attempts to peek the next item.</summary>
+    /// <param name="nextSubsequence">Retrieved next item.</param>
+    /// <param name="isStillBigEndian">Whether it still should be parsed in big endian.</param>
+    /// <returns><c>true</c> if anything is retrieved.</returns>
+    /// <exception cref="EncoderFallbackException">The sequence is not a fully valid Unicode sequence, and
+    /// <see cref="UtfEnumeratorFlags.ThrowOnFirstError"/> is set.</exception>
+    public readonly bool TryPeekNext(out Subsequence nextSubsequence, out bool isStillBigEndian)
+    {
+        var offset = Current.ByteOffset + Current.ByteLength;
+        isStillBigEndian = _isBigEndian;
+        while (true)
+        {
+            var subspan = _data[offset..];
+
+            if (subspan.IsEmpty)
+            {
+                nextSubsequence = default;
+                return false;
+            }
+
+            UtfValue value;
+            int length;
+            var isBroken =
+                _numBytesPerUnit switch
+                {
+                    1 => !UtfValue.TryDecode8(subspan, out value, out length),
+                    2 => !UtfValue.TryDecode16(subspan, isStillBigEndian, out value, out length),
+                    4 => !UtfValue.TryDecode32(subspan, isStillBigEndian, out value, out length),
+                    _ => throw new InvalidOperationException(),
+                };
+            if (!isBroken && value.IntValue == 0xFFFE)
+            {
+                if ((_flags & UtfEnumeratorFlags.DisrespectByteOrderMask) == 0)
+                {
+                    isStillBigEndian = !isStillBigEndian;
+                    value = 0xFEFF;
+                }
+
+                if ((_flags & UtfEnumeratorFlags.YieldByteOrderMask) == 0)
+                {
+                    offset += length;
+                    continue;
+                }
+            }
+
+            if (isBroken || !Rune.IsValid(value))
+            {
+                switch (_flags & UtfEnumeratorFlags.ErrorHandlingMask)
+                {
+                    case UtfEnumeratorFlags.ReplaceErrors:
+                        break;
+
+                    case UtfEnumeratorFlags.IgnoreErrors:
+                        offset = Math.Min(offset + _numBytesPerUnit, _data.Length);
+                        continue;
+
+                    case UtfEnumeratorFlags.ThrowOnFirstError:
+                        if (isBroken)
+                            throw new EncoderFallbackException($"0x{subspan[0]:X02} is not a valid sequence.");
+                        throw new EncoderFallbackException(
+                            $"U+{value.UIntValue:X08} is not a valid Unicode codepoint.");
+
+                    case UtfEnumeratorFlags.TerminateOnFirstError:
+                    default:
+                        nextSubsequence = default;
+                        return false;
+                }
+            }
+
+            if (isBroken)
+                value = subspan[0];
+
+            if (value == SeString.StartByte && (_flags & UtfEnumeratorFlags.Utf8SeString) != 0)
+            {
+                var e = new ReadOnlySeStringSpan(subspan).GetEnumerator();
+                e.MoveNext();
+                switch (_flags & UtfEnumeratorFlags.ErrorHandlingMask)
+                {
+                    case var _ when e.Current.Type is ReadOnlySePayloadType.Macro:
+                        nextSubsequence = Subsequence.FromPayload(
+                            e.Current.MacroCode,
+                            offset,
+                            e.Current.EnvelopeByteLength);
+                        return true;
+
+                    case UtfEnumeratorFlags.ReplaceErrors:
+                        value = '\uFFFE';
+                        length = e.Current.EnvelopeByteLength;
+                        isBroken = true;
+                        break;
+
+                    case UtfEnumeratorFlags.IgnoreErrors:
+                        offset = Math.Min(offset + e.Current.EnvelopeByteLength, _data.Length);
+                        continue;
+
+                    case UtfEnumeratorFlags.ThrowOnFirstError:
+                        throw new EncoderFallbackException("Invalid SeString payload.");
+
+                    case UtfEnumeratorFlags.TerminateOnFirstError:
+                    default:
+                        nextSubsequence = default;
+                        return false;
+                }
+            }
+
+            nextSubsequence = Subsequence.FromUnicode(value, offset, length, isBroken);
+            return true;
+        }
+    }
+
+    /// <inheritdoc cref="IEnumerator.MoveNext"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool MoveNext()
+    {
+        if (!TryPeekNext(out var next, out var isStillBigEndian))
+            return false;
+
+        Current = next;
+        _isBigEndian = isStillBigEndian;
+        return true;
+    }
+
+    /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public UtfEnumerator GetEnumerator() => new(_data, _flags);
+
+    /// <summary>A part of a UTF-N sequence containing one codepoint.</summary>
+    [StructLayout(LayoutKind.Explicit, Size = 16)]
+    [DebuggerDisplay("[{ByteOffset}, {ByteLength}] {Value}")]
+    public readonly struct Subsequence : IEquatable<Subsequence>
+    {
+        /// <summary>The codepoint. Valid if <see cref="IsSeStringPayload"/> is <c>false</c>.</summary>
+        [FieldOffset(0)]
+        public readonly UtfValue Value;
+
+        /// <summary>The macro code. Valid if <see cref="IsSeStringPayload"/> is <c>true</c>.</summary>
+        [FieldOffset(0)]
+        public readonly MacroCode MacroCode;
+
+        /// <summary>The offset of this part of a UTF-8 sequence.</summary>
+        [FieldOffset(4)]
+        public readonly int ByteOffset;
+
+        /// <summary>The length of this part of a UTF-8 sequence.</summary>
+        /// <remarks>This may not match <see cref="UtfValue.Length8"/>, if <see cref="BrokenSequence"/> is <c>true</c>.
+        /// </remarks>
+        [FieldOffset(8)]
+        public readonly int ByteLength;
+
+        /// <summary>Whether this part of the UTF-8 sequence is broken.</summary>
+        [FieldOffset(12)]
+        public readonly bool BrokenSequence;
+
+        /// <summary>Whether this part of the SeString sequence is a payload.</summary>
+        [FieldOffset(13)]
+        public readonly bool IsSeStringPayload;
+
+        /// <summary>Storage at byte offset 0, for fast <see cref="Equals(Subsequence)"/> implementation.</summary>
+        [FieldOffset(0)]
+        private readonly ulong storage0;
+
+        /// <summary>Storage at byte offset 8, for fast <see cref="Equals(Subsequence)"/> implementation.</summary>
+        [FieldOffset(8)]
+        private readonly ulong storage1;
+
+        /// <summary>Initializes a new instance of the <see cref="Subsequence"/> struct.</summary>
+        /// <param name="value">The value.</param>
+        /// <param name="byteOffset">The byte offset of this part of a UTF-N sequence.</param>
+        /// <param name="byteLength">The byte length of this part of a UTF-N sequence.</param>
+        /// <param name="brokenSequence">Whether this part of the UTF-N sequence is broken.</param>
+        /// <param name="isSeStringPayload">Whether this part of the SeString sequence is a payload.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private Subsequence(uint value, int byteOffset, int byteLength, bool brokenSequence, bool isSeStringPayload)
+        {
+            Value = new(value);
+            ByteOffset = byteOffset;
+            ByteLength = byteLength;
+            BrokenSequence = brokenSequence;
+            IsSeStringPayload = isSeStringPayload;
+        }
+
+        /// <summary>Gets the effective <c>char</c> value, with invalid or non-representable codepoints replaced.
+        /// </summary>
+        /// <value><see cref="char.MaxValue"/> if the character should not be displayed at all.</value>
+        public char EffectiveChar
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => EffectiveInt is var i and >= 0 and < char.MaxValue ? (char)i : char.MaxValue;
+        }
+
+        /// <summary>Gets the effective <c>int</c> value, with invalid codepoints replaced.</summary>
+        /// <value><see cref="char.MaxValue"/> if the character should not be displayed at all.</value>
+        public int EffectiveInt =>
+            IsSeStringPayload
+                ? RepresentativeCharFor(MacroCode)
+                : BrokenSequence || !Value.TryGetRune(out var rune)
+                    ? 0xFFFD
+                    : rune.Value;
+
+        /// <summary>Gets the effective <see cref="Rune"/> value, with invalid codepoints replaced.</summary>
+        /// <value><see cref="char.MaxValue"/> if the character should not be displayed at all.</value>
+        public Rune EffectiveRune
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => new(EffectiveInt);
+        }
+
+        /// <summary>Compares two values to determine equality.</summary>
+        /// <param name="left">The value to compare with <paramref name="right" />.</param>
+        /// <param name="right">The value to compare with <paramref name="left" />.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="left" /> is equal to <paramref name="right" />; otherwise, <see langword="false" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator ==(Subsequence left, Subsequence right) => left.Equals(right);
+
+        /// <summary>Compares two values to determine inequality.</summary>
+        /// <param name="left">The value to compare with <paramref name="right" />.</param>
+        /// <param name="right">The value to compare with <paramref name="left" />.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="left" /> is not equal to <paramref name="right" />; otherwise, <see langword="false" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator !=(Subsequence left, Subsequence right) => !left.Equals(right);
+
+        /// <summary>Creates a new instance of the <see cref="Subsequence"/> struct from a Unicode value.</summary>
+        /// <param name="codepoint">The codepoint.</param>
+        /// <param name="byteOffset">The byte offset of this part of a UTF-N sequence.</param>
+        /// <param name="byteLength">The byte length of this part of a UTF-N sequence.</param>
+        /// <param name="brokenSequence">Whether this part of the UTF-N sequence is broken.</param>
+        /// <returns>A new instance.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Subsequence FromUnicode(uint codepoint, int byteOffset, int byteLength, bool brokenSequence) =>
+            new(codepoint, byteOffset, byteLength, brokenSequence, false);
+
+        /// <summary>Creates a new instance of the <see cref="Subsequence"/> struct from a SeString payload.</summary>
+        /// <param name="macroCode">The macro code.</param>
+        /// <param name="byteOffset">The byte offset of this part of a UTF-N sequence.</param>
+        /// <param name="byteLength">The byte length of this part of a UTF-N sequence.</param>
+        /// <returns>A new instance.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Subsequence FromPayload(MacroCode macroCode, int byteOffset, int byteLength) =>
+            new((uint)macroCode, byteOffset, byteLength, false, true);
+
+        /// <summary>Tests whether this subsequence contains a valid Unicode codepoint.</summary>
+        /// <returns><c>true</c> if this subsequence contains a valid Unicode codepoint.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsValid() => !BrokenSequence && Rune.IsValid(Value);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Equals(Subsequence other) => storage0 == other.storage0 && storage1 == other.storage1;
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override bool Equals(object? obj) => obj is Subsequence other && Equals(other);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override int GetHashCode() => HashCode.Combine(storage0, storage1);
+    }
+}

--- a/src/Lumina/Text/UtfEnumerator.cs
+++ b/src/Lumina/Text/UtfEnumerator.cs
@@ -25,25 +25,20 @@ public ref struct UtfEnumerator
     {
         _data = data;
         _flags = flags;
-        _numBytesPerUnit = (_flags & UtfEnumeratorFlags.UtfMask) switch
-        {
-            UtfEnumeratorFlags.Utf8 or UtfEnumeratorFlags.Utf8SeString => 1,
-            UtfEnumeratorFlags.Utf16 => 2,
-            UtfEnumeratorFlags.Utf32 => 4,
-            _ => throw new ArgumentOutOfRangeException(nameof(flags), flags, "Multiple UTF flag specified."),
-        };
-        _isBigEndian = (flags & UtfEnumeratorFlags.EndiannessMask) switch
-        {
-            UtfEnumeratorFlags.NativeEndian => !BitConverter.IsLittleEndian,
-            UtfEnumeratorFlags.LittleEndian => false,
-            UtfEnumeratorFlags.BigEndian => true,
-            _ => throw new ArgumentOutOfRangeException(nameof(flags), flags, "Multiple endianness flag specified."),
-        };
+        _numBytesPerUnit = _flags.GetMinimumCodepointByteCount();
+        _isBigEndian = flags.IsEffectivelyBigEndian();
     }
 
+    /// <summary>Gets the backing data.</summary>
     public ReadOnlySpan<byte> Data => _data;
+
+    /// <summary>Gets the flags used by this enumerator.</summary>
     public UtfEnumeratorFlags EnumeratorFlags => _flags;
+
+    /// <summary>Gets the minimum number of bytes per codepoint.</summary>
     public int NumBytesPerUnit => _numBytesPerUnit;
+
+    /// <summary>Gets a value indicating whether <see cref="Data"/> is being parsed in big endian.</summary>
     public bool IsBigEndian => _isBigEndian;
 
     /// <inheritdoc cref="IEnumerator.Current"/>

--- a/src/Lumina/Text/UtfEnumerator.cs
+++ b/src/Lumina/Text/UtfEnumerator.cs
@@ -41,6 +41,11 @@ public ref struct UtfEnumerator
         };
     }
 
+    public ReadOnlySpan<byte> Data => _data;
+    public UtfEnumeratorFlags EnumeratorFlags => _flags;
+    public int NumBytesPerUnit => _numBytesPerUnit;
+    public bool IsBigEndian => _isBigEndian;
+
     /// <inheritdoc cref="IEnumerator.Current"/>
     public Subsequence Current { get; private set; } = default;
 
@@ -182,6 +187,10 @@ public ref struct UtfEnumerator
         }
     }
 
+    /// <summary>Clones this enumerator, using the current state.</summary>
+    /// <returns>Cloned instance of this enumerator.</returns>
+    public readonly UtfEnumerator Clone() => this;
+
     /// <inheritdoc cref="IEnumerator.MoveNext"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool MoveNext()
@@ -279,13 +288,33 @@ public ref struct UtfEnumerator
             get => new(EffectiveInt);
         }
 
+        /// <summary>Converts a <see cref="Subsequence"/> to the effective codepoint value, with invalid codepoints replaced.</summary>
+        /// <param name="s"><see cref="Subsequence"/> to convert.</param>
+        /// <returns>Converted value.</returns>
+        public static implicit operator char( scoped in Subsequence s ) => s.EffectiveChar;
+
+        /// <summary>Converts a <see cref="Subsequence"/> to the effective codepoint value, with invalid codepoints replaced.</summary>
+        /// <param name="s"><see cref="Subsequence"/> to convert.</param>
+        /// <returns>Converted value.</returns>
+        public static implicit operator int( scoped in Subsequence s ) => s.EffectiveInt;
+
+        /// <summary>Converts a <see cref="Subsequence"/> to the effective codepoint value, with invalid codepoints replaced.</summary>
+        /// <param name="s"><see cref="Subsequence"/> to convert.</param>
+        /// <returns>Converted value.</returns>
+        public static implicit operator uint( scoped in Subsequence s ) => unchecked( (uint) s.EffectiveInt );
+
+        /// <summary>Converts a <see cref="Subsequence"/> to the effective <see cref="Rune"/> value, with invalid codepoints replaced.</summary>
+        /// <param name="s"><see cref="Subsequence"/> to convert.</param>
+        /// <returns>Converted value.</returns>
+        public static implicit operator Rune( scoped in Subsequence s ) => s.EffectiveRune;
+
         /// <summary>Compares two values to determine equality.</summary>
         /// <param name="left">The value to compare with <paramref name="right" />.</param>
         /// <param name="right">The value to compare with <paramref name="left" />.</param>
         /// <returns>
         /// <see langword="true" /> if <paramref name="left" /> is equal to <paramref name="right" />; otherwise, <see langword="false" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator ==(Subsequence left, Subsequence right) => left.Equals(right);
+        public static bool operator ==(scoped in Subsequence left, scoped in Subsequence right) => left.Equals(right);
 
         /// <summary>Compares two values to determine inequality.</summary>
         /// <param name="left">The value to compare with <paramref name="right" />.</param>
@@ -293,7 +322,7 @@ public ref struct UtfEnumerator
         /// <returns>
         /// <see langword="true" /> if <paramref name="left" /> is not equal to <paramref name="right" />; otherwise, <see langword="false" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator !=(Subsequence left, Subsequence right) => !left.Equals(right);
+        public static bool operator !=(scoped in Subsequence left, scoped in Subsequence right) => !left.Equals(right);
 
         /// <summary>Creates a new instance of the <see cref="Subsequence"/> struct from a Unicode value.</summary>
         /// <param name="codepoint">The codepoint.</param>

--- a/src/Lumina/Text/UtfEnumeratorFlags.cs
+++ b/src/Lumina/Text/UtfEnumeratorFlags.cs
@@ -1,0 +1,60 @@
+using System;
+
+namespace Lumina.Text;
+
+/// <summary>Flags on enumerating a Unicode sequence.</summary>
+[Flags]
+public enum UtfEnumeratorFlags
+{
+    /// <summary>Use the default configuration of <see cref="Utf8"/> and <see cref="ReplaceErrors"/>.</summary>
+    Default = default,
+
+    /// <summary>Enumerate as UTF-8 (the default.)</summary>
+    Utf8 = Default,
+    
+    /// <summary>Enumerate as UTF-8 in a SeString.</summary>
+    Utf8SeString = 1 << 1,
+
+    /// <summary>Enumerate as UTF-16.</summary>
+    Utf16 = 1 << 2,
+
+    /// <summary>Enumerate as UTF-32.</summary>
+    Utf32 = 1 << 3,
+
+    /// <summary>Bitmask for specifying the encoding.</summary>
+    UtfMask = Utf8 | Utf8SeString | Utf16 | Utf32,
+
+    /// <summary>On error, replace to U+FFFD (REPLACEMENT CHARACTER, the default.)</summary>
+    ReplaceErrors = Default,
+
+    /// <summary>On error, drop the invalid byte.</summary>
+    IgnoreErrors = 1 << 4,
+
+    /// <summary>On error, stop the handling.</summary>
+    TerminateOnFirstError = 1 << 5,
+
+    /// <summary>On error, throw an exception.</summary>
+    ThrowOnFirstError = 1 << 6,
+
+    /// <summary>Bitmask for specifying the error handling mode.</summary>
+    ErrorHandlingMask = ReplaceErrors | IgnoreErrors | TerminateOnFirstError | ThrowOnFirstError,
+
+    /// <summary>Use the current system native endianness from <see cref="BitConverter.IsLittleEndian"/>
+    /// (the default.)</summary>
+    NativeEndian = Default,
+
+    /// <summary>Use little endianness.</summary>
+    LittleEndian = 1 << 7,
+
+    /// <summary>Use big endianness.</summary>
+    BigEndian = 1 << 8,
+
+    /// <summary>Bitmask for specifying endianness.</summary>
+    EndiannessMask = NativeEndian | LittleEndian | BigEndian,
+
+    /// <summary>Disrespect byte order mask.</summary>
+    DisrespectByteOrderMask = 1 << 9,
+
+    /// <summary>Yield byte order masks, if it shows up.</summary>
+    YieldByteOrderMask = 1 << 10,
+}

--- a/src/Lumina/Text/UtfEnumeratorFlags.cs
+++ b/src/Lumina/Text/UtfEnumeratorFlags.cs
@@ -11,7 +11,7 @@ public enum UtfEnumeratorFlags
 
     /// <summary>Enumerate as UTF-8 (the default.)</summary>
     Utf8 = Default,
-    
+
     /// <summary>Enumerate as UTF-8 in a SeString.</summary>
     Utf8SeString = 1 << 1,
 

--- a/src/Lumina/Text/UtfEnumeratorFlagsExtensions.cs
+++ b/src/Lumina/Text/UtfEnumeratorFlagsExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Lumina.Text;
+
+/// <summary>Utilities for <see cref="UtfEnumeratorFlags"/>.</summary>
+public static class UtfEnumeratorFlagsExtensions
+{
+    /// <summary>Gets the minimum number of bytes taken for a single codepoint.</summary>
+    /// <param name="flags">Flags.</param>
+    /// <returns>Minimum number of bytes per codepoint.</returns>
+    public static byte GetMinimumCodepointByteCount( this UtfEnumeratorFlags flags ) => ( flags & UtfEnumeratorFlags.UtfMask ) switch
+    {
+        UtfEnumeratorFlags.Utf8 or UtfEnumeratorFlags.Utf8SeString => 1,
+        UtfEnumeratorFlags.Utf16 => 2,
+        UtfEnumeratorFlags.Utf32 => 4,
+        _ => throw new ArgumentOutOfRangeException( nameof( flags ), flags, "Multiple UTF flag specified." ),
+    };
+
+    /// <summary>Gets a value indicating whether to begin parsing in big endian mode.</summary>
+    /// <param name="flags">Flags.</param>
+    /// <returns><c>true</c> if bytes should be interpreted in big endian.</returns>
+    public static bool IsEffectivelyBigEndian( this UtfEnumeratorFlags flags ) => ( flags & UtfEnumeratorFlags.EndiannessMask ) switch
+    {
+        UtfEnumeratorFlags.NativeEndian => !BitConverter.IsLittleEndian,
+        UtfEnumeratorFlags.LittleEndian => false,
+        UtfEnumeratorFlags.BigEndian => true,
+        _ => throw new ArgumentOutOfRangeException( nameof( flags ), flags, "Multiple endianness flag specified." ),
+    };
+}

--- a/src/Lumina/Text/UtfValue.cs
+++ b/src/Lumina/Text/UtfValue.cs
@@ -1,0 +1,726 @@
+using System;
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Lumina.Text;
+
+/// <summary>Represents a single value to be used in a UTF-N byte sequence.</summary>
+[StructLayout(LayoutKind.Explicit, Size = 4)]
+[DebuggerDisplay("0x{IntValue,h} ({CharValue})")]
+public readonly struct UtfValue : IEquatable<UtfValue>, IComparable<UtfValue>
+{
+    /// <summary>The Unicode codepoint in <c>int</c>, that may not be in a valid range.</summary>
+    [FieldOffset(0)]
+    public readonly int IntValue;
+
+    /// <summary>The Unicode codepoint in <c>uint</c>, that may not be in a valid range.</summary>
+    [FieldOffset(0)]
+    public readonly uint UIntValue;
+
+    /// <summary>The high UInt16 value in <c>char</c>, that may have been cut off if outside BMP.</summary>
+    [FieldOffset(0)]
+    public readonly char CharValue;
+
+    /// <summary>Initializes a new instance of the <see cref="UtfValue"/> struct.</summary>
+    /// <param name="value">The raw codepoint value.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public UtfValue(uint value) => UIntValue = value;
+
+    /// <inheritdoc cref="UtfValue(uint)"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public UtfValue(int value) => IntValue = value;
+
+    /// <summary>Gets the length of this codepoint, encoded in UTF-8.</summary>
+    public int Length8
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetEncodedLength8(this);
+    }
+
+    /// <summary>Gets the length of this codepoint, encoded in UTF-16.</summary>
+    public int Length16
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetEncodedLength16(this);
+    }
+
+    /// <summary>Gets the short name, if supported.</summary>
+    /// <returns>The buffer containing the short name, or empty if unsupported.</returns>
+    public ReadOnlySpan<char> ShortName
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetShortName(this);
+    }
+
+    /// <summary>Gets the codepoint as a <see cref="uint"/>.</summary>
+    /// <param name="c">Value to unwrap.</param>
+    /// <returns>Unwrapped value.</returns>
+    public static implicit operator uint(UtfValue c) => c.UIntValue;
+
+    /// <summary>Gets the codepoint as a <see cref="int"/>.</summary>
+    /// <param name="c">Value to unwrap.</param>
+    /// <returns>Unwrapped value.</returns>
+    public static implicit operator int(UtfValue c) => c.IntValue;
+
+    /// <summary>Creates a new instance of <see cref="UtfValue"/> struct, wrapping a <see cref="byte"/>.</summary>
+    /// <param name="c">Value to wrap.</param>
+    /// <returns>Value wrapped as a <see cref="UtfValue"/>.</returns>
+    public static implicit operator UtfValue(byte c) => new(c);
+
+    /// <summary>Creates a new instance of <see cref="UtfValue"/> struct, wrapping a <see cref="sbyte"/>.</summary>
+    /// <param name="c">Value to wrap.</param>
+    /// <returns>Value wrapped as a <see cref="UtfValue"/>.</returns>
+    public static implicit operator UtfValue(sbyte c) => new(c);
+
+    /// <summary>Creates a new instance of <see cref="UtfValue"/> struct, wrapping a <see cref="ushort"/>.</summary>
+    /// <param name="c">Value to wrap.</param>
+    /// <returns>Value wrapped as a <see cref="UtfValue"/>.</returns>
+    public static implicit operator UtfValue(ushort c) => new(c);
+
+    /// <summary>Creates a new instance of <see cref="UtfValue"/> struct, wrapping a <see cref="short"/>.</summary>
+    /// <param name="c">Value to wrap.</param>
+    /// <returns>Value wrapped as a <see cref="UtfValue"/>.</returns>
+    public static implicit operator UtfValue(short c) => new(c);
+
+    /// <summary>Creates a new instance of <see cref="UtfValue"/> struct, wrapping a <see cref="uint"/>.</summary>
+    /// <param name="c">Value to wrap.</param>
+    /// <returns>Value wrapped as a <see cref="UtfValue"/>.</returns>
+    public static implicit operator UtfValue(uint c) => new(c);
+
+    /// <summary>Creates a new instance of <see cref="UtfValue"/> struct, wrapping a <see cref="int"/>.</summary>
+    /// <param name="c">Value to wrap.</param>
+    /// <returns>Value wrapped as a <see cref="UtfValue"/>.</returns>
+    public static implicit operator UtfValue(int c) => new(c);
+
+    /// <summary>Creates a new instance of <see cref="UtfValue"/> struct, wrapping a <see cref="char"/>.</summary>
+    /// <param name="c">Value to wrap.</param>
+    /// <returns>Value wrapped as a <see cref="UtfValue"/>.</returns>
+    public static implicit operator UtfValue(char c) => new(c);
+
+    /// <summary>Creates a new instance of <see cref="UtfValue"/> struct, wrapping a <see cref="Rune"/>.</summary>
+    /// <param name="c">Value to wrap.</param>
+    /// <returns>Value wrapped as a <see cref="UtfValue"/>.</returns>
+    public static implicit operator UtfValue(Rune c) => new(c.Value);
+
+    /// <summary>Compares two values to determine equality.</summary>
+    /// <param name="left">The value to compare with <paramref name="right" />.</param>
+    /// <param name="right">The value to compare with <paramref name="left" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="left" /> is equal to <paramref name="right" />; otherwise, <see langword="false" />.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator ==(UtfValue left, UtfValue right) => left.Equals(right);
+
+    /// <summary>Compares two values to determine inequality.</summary>
+    /// <param name="left">The value to compare with <paramref name="right" />.</param>
+    /// <param name="right">The value to compare with <paramref name="left" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="left" /> is not equal to <paramref name="right" />; otherwise, <see langword="false" />.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator !=(UtfValue left, UtfValue right) => !left.Equals(right);
+
+    /// <summary>Compares two values to determine which is less.</summary>
+    /// <param name="left">The value to compare with <paramref name="right" />.</param>
+    /// <param name="right">The value to compare with <paramref name="left" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="left" /> is less than <paramref name="right" />; otherwise, <see langword="false" />.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator <(UtfValue left, UtfValue right) => left.CompareTo(right) < 0;
+
+    /// <summary>Compares two values to determine which is less or equal.</summary>
+    /// <param name="left">The value to compare with <paramref name="right" />.</param>
+    /// <param name="right">The value to compare with <paramref name="left" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="left" /> is less than or equal to <paramref name="right" />; otherwise, <see langword="false" />.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator >(UtfValue left, UtfValue right) => left.CompareTo(right) > 0;
+
+    /// <summary>Compares two values to determine which is greater.</summary>
+    /// <param name="left">The value to compare with <paramref name="right" />.</param>
+    /// <param name="right">The value to compare with <paramref name="left" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="left" /> is greater than <paramref name="right" />; otherwise, <see langword="false" />.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator <=(UtfValue left, UtfValue right) => left.CompareTo(right) <= 0;
+
+    /// <summary>Compares two values to determine which is greater or equal.</summary>
+    /// <param name="left">The value to compare with <paramref name="right" />.</param>
+    /// <param name="right">The value to compare with <paramref name="left" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="left" /> is greater than or equal to <paramref name="right" />; otherwise, <see langword="false" />.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator >=(UtfValue left, UtfValue right) => left.CompareTo(right) >= 0;
+
+    /// <summary>Gets the short name of the codepoint, for some select codepoints.</summary>
+    /// <param name="codepoint">The codepoint.</param>
+    /// <returns>The value.</returns>
+    public static ReadOnlySpan<char> GetShortName(int codepoint) =>
+        codepoint switch
+        {
+            0x00 => "NUL",
+            0x01 => "SOH",
+            0x02 => "STX",
+            0x03 => "ETX",
+            0x04 => "EOT",
+            0x05 => "ENQ",
+            0x06 => "ACK",
+            0x07 => "BEL",
+            0x08 => "BS",
+            0x09 => "HT",
+            0x0a => "LF",
+            0x0b => "VT",
+            0x0c => "FF",
+            0x0d => "CR",
+            0x0e => "SO",
+            0x0f => "SI",
+
+            0x10 => "DLE",
+            0x11 => "DC1",
+            0x12 => "DC2",
+            0x13 => "DC3",
+            0x14 => "DC4",
+            0x15 => "NAK",
+            0x16 => "SYN",
+            0x17 => "SOH",
+            0x18 => "CAN",
+            0x19 => "EOM",
+            0x1a => "SUB",
+            0x1b => "ESC",
+            0x1c => "FS",
+            0x1d => "GS",
+            0x1e => "RS",
+            0x1f => "US",
+
+            0x80 => "PAD",
+            0x81 => "HOP",
+            0x82 => "BPH",
+            0x83 => "NBH",
+            0x84 => "IND",
+            0x85 => "NEL",
+            0x86 => "SSA",
+            0x87 => "ESA",
+            0x88 => "HTS",
+            0x89 => "HTJ",
+            0x8a => "VTS",
+            0x8b => "PLD",
+            0x8c => "PLU",
+            0x8d => "RI",
+            0x8e => "SS2",
+            0x8f => "SS3",
+
+            0x90 => "DCS",
+            0x91 => "PU1",
+            0x92 => "PU2",
+            0x93 => "STS",
+            0x94 => "CCH",
+            0x95 => "MW",
+            0x96 => "SPA",
+            0x97 => "EPA",
+            0x98 => "SOS",
+            0x99 => "SGC",
+            0x9a => "SCI",
+            0x9b => "CSI",
+            0x9c => "ST",
+            0x9d => "OSC",
+            0x9e => "PM",
+            0x9f => "APC",
+
+            0xa0 => "NBSP",
+            0xad => "SHY",
+
+            _ => default,
+        };
+
+    /// <summary>Gets the length of the codepoint, when encoded in UTF-8.</summary>
+    /// <param name="codepoint">The codepoint to encode.</param>
+    /// <returns>The length.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int GetEncodedLength8(int codepoint) => (uint)codepoint switch
+    {
+        < 1u << 7 => 1,
+        < 1u << 11 => 2,
+        < 1u << 16 => 3,
+        < 1u << 21 => 4,
+        // Not a valid Unicode codepoint anymore below.
+        < 1u << 26 => 5,
+        < 1u << 31 => 6,
+        _ => 7,
+    };
+
+    /// <summary>Gets the length of the codepoint, when encoded in UTF-16.</summary>
+    /// <param name="codepoint">The codepoint to encode.</param>
+    /// <returns>The length.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int GetEncodedLength16(int codepoint) => (uint)codepoint switch
+    {
+        < 0x10000 => 2,
+        < 0x10000 + (1 << 20) => 4,
+        // Not a valid Unicode codepoint anymore below.
+        < 0x10000 + (1 << 30) => 6,
+        _ => 8,
+    };
+
+    /// <inheritdoc cref="TryDecode8(ReadOnlySpan{byte}, out UtfValue, out int)"/>
+    /// <remarks>Trims <paramref name="source"/> at beginning by <paramref name="length"/>.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool TryDecode8(ref ReadOnlySpan<byte> source, out UtfValue value, out int length)
+    {
+        var v = TryDecode8(source, out value, out length);
+        source = source[length..];
+        return v;
+    }
+
+    /// <summary>Attempts to decode a value from a UTF-8 byte sequence.</summary>
+    /// <param name="source">The span to decode from.</param>
+    /// <param name="value">The decoded value.</param>
+    /// <param name="length">The length of the consumed bytes. <c>1</c> if sequence is broken.</param>
+    /// <returns><c>true</c> if <paramref name="source"/> is successfully decoded.</returns>
+    /// <remarks>Codepoints that results in <c>false</c> from <see cref="Rune.IsValid(int)"/> can still be returned,
+    /// including unpaired surrogate characters, or codepoints above U+10FFFFF. This function returns a value only
+    /// indicating whether the sequence could be decoded into a number, without being too short.</remarks>
+    public static unsafe bool TryDecode8(ReadOnlySpan<byte> source, out UtfValue value, out int length)
+    {
+        if (source.IsEmpty)
+        {
+            value = default;
+            length = 0;
+            return false;
+        }
+
+        fixed (byte* ptr = source)
+        {
+            if ((ptr[0] & 0x80) == 0)
+            {
+                length = 1;
+                value = ptr[0];
+            }
+            else if ((ptr[0] & 0b11100000) == 0b11000000 && source.Length >= 2
+                     && ((uint)ptr[1] & 0b11000000) == 0b10000000)
+            {
+                length = 2;
+                value = (((uint)ptr[0] & 0x1F) << 6) |
+                        (((uint)ptr[1] & 0x3F) << 0);
+            }
+            else if (((uint)ptr[0] & 0b11110000) == 0b11100000 && source.Length >= 3
+                     && ((uint)ptr[1] & 0b11000000) == 0b10000000
+                     && ((uint)ptr[2] & 0b11000000) == 0b10000000)
+            {
+                length = 3;
+                value = (((uint)ptr[0] & 0x0F) << 12) |
+                        (((uint)ptr[1] & 0x3F) << 6) |
+                        (((uint)ptr[2] & 0x3F) << 0);
+            }
+            else if (((uint)ptr[0] & 0b11111000) == 0b11110000 && source.Length >= 4
+                     && ((uint)ptr[1] & 0b11000000) == 0b10000000
+                     && ((uint)ptr[2] & 0b11000000) == 0b10000000
+                     && ((uint)ptr[3] & 0b11000000) == 0b10000000)
+            {
+                length = 4;
+                value = (((uint)ptr[0] & 0x07) << 18) |
+                        (((uint)ptr[1] & 0x3F) << 12) |
+                        (((uint)ptr[2] & 0x3F) << 6) |
+                        (((uint)ptr[3] & 0x3F) << 0);
+            }
+            else if (((uint)ptr[0] & 0b11111100) == 0b11111000 && source.Length >= 5
+                     && ((uint)ptr[1] & 0b11000000) == 0b10000000
+                     && ((uint)ptr[2] & 0b11000000) == 0b10000000
+                     && ((uint)ptr[3] & 0b11000000) == 0b10000000
+                     && ((uint)ptr[4] & 0b11000000) == 0b10000000)
+            {
+                length = 5;
+                value = (((uint)ptr[0] & 0x03) << 24) |
+                        (((uint)ptr[1] & 0x3F) << 18) |
+                        (((uint)ptr[2] & 0x3F) << 12) |
+                        (((uint)ptr[3] & 0x3F) << 6) |
+                        (((uint)ptr[4] & 0x3F) << 0);
+            }
+            else if (((uint)ptr[0] & 0b11111110) == 0b11111100 && source.Length >= 6
+                     && ((uint)ptr[1] & 0b11000000) == 0b10000000
+                     && ((uint)ptr[2] & 0b11000000) == 0b10000000
+                     && ((uint)ptr[3] & 0b11000000) == 0b10000000
+                     && ((uint)ptr[4] & 0b11000000) == 0b10000000
+                     && ((uint)ptr[5] & 0b11000000) == 0b10000000)
+            {
+                length = 6;
+                value = (((uint)ptr[0] & 0x01) << 30) |
+                        (((uint)ptr[1] & 0x3F) << 24) |
+                        (((uint)ptr[2] & 0x3F) << 18) |
+                        (((uint)ptr[3] & 0x3F) << 12) |
+                        (((uint)ptr[4] & 0x3F) << 6) |
+                        (((uint)ptr[5] & 0x3F) << 0);
+            }
+            else if (((uint)ptr[0] & 0b11111111) == 0b11111110 && source.Length >= 7
+                     && ((uint)ptr[1] & 0b11111100) == 0b10000000
+                     && ((uint)ptr[2] & 0b11000000) == 0b10000000
+                     && ((uint)ptr[3] & 0b11000000) == 0b10000000
+                     && ((uint)ptr[4] & 0b11000000) == 0b10000000
+                     && ((uint)ptr[5] & 0b11000000) == 0b10000000
+                     && ((uint)ptr[6] & 0b11000000) == 0b10000000)
+            {
+                length = 7;
+                value = (((uint)ptr[1] & 0x03) << 30) |
+                        (((uint)ptr[2] & 0x3F) << 24) |
+                        (((uint)ptr[3] & 0x3F) << 18) |
+                        (((uint)ptr[4] & 0x3F) << 12) |
+                        (((uint)ptr[5] & 0x3F) << 6) |
+                        (((uint)ptr[6] & 0x3F) << 0);
+            }
+            else
+            {
+                length = 1;
+                value = default;
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    /// <inheritdoc cref="TryDecode16(ReadOnlySpan{byte}, bool, out UtfValue, out int)"/>
+    /// <remarks>Trims <paramref name="source"/> at beginning by <paramref name="length"/>.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool TryDecode16(ref ReadOnlySpan<byte> source, bool be, out UtfValue value, out int length)
+    {
+        var v = TryDecode16(source, be, out value, out length);
+        source = source[length..];
+        return v;
+    }
+
+    /// <summary>Attempts to decode a value from a UTF-16 byte sequence.</summary>
+    /// <param name="source">The span to decode from.</param>
+    /// <param name="be">Whether to use big endian.</param>
+    /// <param name="value">The decoded value.</param>
+    /// <param name="length">The length of the consumed bytes. <c>1</c> if cut short.
+    /// <c>2</c> if sequence is broken.</param>
+    /// <returns><c>true</c> if <paramref name="source"/> is successfully decoded.</returns>
+    /// <remarks>Codepoints that results in <c>false</c> from <see cref="Rune.IsValid(int)"/> can still be returned,
+    /// including unpaired surrogate characters, or codepoints above U+10FFFFF. This function returns a value only
+    /// indicating whether the sequence could be decoded into a number, without being too short.</remarks>
+    public static unsafe bool TryDecode16(ReadOnlySpan<byte> source, bool be, out UtfValue value, out int length)
+    {
+        if (source.Length < 2)
+        {
+            value = default;
+            length = source.Length;
+            return false;
+        }
+
+        fixed (byte* ptr = source)
+        {
+            var p16 = (ushort*)ptr;
+            var val = be == BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(*p16) : *p16;
+            if (char.IsHighSurrogate((char)val))
+            {
+                var lookahead1 = source.Length >= 4 ? p16[1] : 0;
+                var lookahead2 = source.Length >= 6 ? p16[2] : 0;
+                var lookahead3 = source.Length >= 8 ? p16[3] : 0;
+                if (char.IsLowSurrogate((char)lookahead1))
+                {
+                    // Not a valid Unicode codepoint anymore inside the block below.
+                    if (char.IsLowSurrogate((char)lookahead2))
+                    {
+                        if (char.IsLowSurrogate((char)lookahead3))
+                        {
+                            value = 0x10000
+                                    + (((val & 0x3) << 30) |
+                                       ((lookahead1 & 0x3FF) << 20) |
+                                       ((lookahead2 & 0x3FF) << 10) |
+                                       ((lookahead3 & 0x3FF) << 0));
+                            length = 8;
+                            return true;
+                        }
+
+                        value = 0x10000
+                                + (((val & 0x3FF) << 20) |
+                                   ((lookahead1 & 0x3FF) << 10) |
+                                   ((lookahead2 & 0x3FF) << 0));
+                        length = 6;
+                        return true;
+                    }
+
+                    value = 0x10000 +
+                            (((val & 0x3FF) << 10) |
+                             ((lookahead1 & 0x3FF) << 0));
+                    length = 4;
+                    return true;
+                }
+            }
+
+            // Calls are supposed to handle unpaired surrogates.
+            value = val;
+            length = 2;
+            return true;
+        }
+    }
+
+    /// <inheritdoc cref="TryDecode32(ReadOnlySpan{byte}, bool, out UtfValue, out int)"/>
+    /// <remarks>Trims <paramref name="source"/> at beginning by <paramref name="length"/>.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool TryDecode32(ref ReadOnlySpan<byte> source, bool be, out UtfValue value, out int length)
+    {
+        var v = TryDecode32(source, be, out value, out length);
+        source = source[length..];
+        return v;
+    }
+
+    /// <summary>Attempts to decode a value from a UTF-32 byte sequence.</summary>
+    /// <param name="source">The span to decode from.</param>
+    /// <param name="be">Whether to use big endian.</param>
+    /// <param name="value">The decoded value.</param>
+    /// <param name="length">The length of the consumed bytes. <c>1 to 3</c> if cut short.
+    /// <c>4</c> if sequence is broken.</param>
+    /// <returns><c>true</c> if <paramref name="source"/> is successfully decoded.</returns>
+    /// <remarks>Codepoints that results in <c>false</c> from <see cref="Rune.IsValid(int)"/> can still be returned,
+    /// including unpaired surrogate characters, or codepoints above U+10FFFFF. This function returns a value only
+    /// indicating whether the sequence could be decoded into a number, without being too short.</remarks>
+    public static bool TryDecode32(ReadOnlySpan<byte> source, bool be, out UtfValue value, out int length)
+    {
+        if (source.Length < 4)
+        {
+            value = default;
+            length = source.Length;
+            return false;
+        }
+
+        length = 4;
+        if ((be && BinaryPrimitives.TryReadInt32BigEndian(source, out var i32))
+            || (!be && BinaryPrimitives.TryReadInt32LittleEndian(source, out i32)))
+        {
+            value = i32;
+            return true;
+        }
+        
+        value = default;
+        return false;
+    }
+
+    /// <summary>Encodes the codepoint to the target in UTF-8.</summary>
+    /// <param name="target">The target stream.</param>
+    /// <param name="codepoint">The codepoint to encode.</param>
+    /// <returns>The length of the encoded data.</returns>
+    /// <remarks>Trims <paramref name="target"/> at beginning by the length.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int Encode8(Stream target, int codepoint)
+    {
+        Span<byte> buf = stackalloc byte[7];
+        Encode8(buf, codepoint, out var length);
+        target.Write(buf[..length]);
+        return length;
+    }
+
+    /// <summary>Encodes the codepoint to the target in UTF-8.</summary>
+    /// <param name="target">The target byte span.</param>
+    /// <param name="codepoint">The codepoint to encode.</param>
+    /// <returns>The length of the encoded data.</returns>
+    /// <remarks>Trims <paramref name="target"/> at beginning by the length.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int Encode8(ref Span<byte> target, int codepoint)
+    {
+        target = Encode8(target, codepoint, out var length);
+        return length;
+    }
+
+    /// <summary>Encodes the codepoint to the target in UTF-8.</summary>
+    /// <param name="target">The optional target byte span.</param>
+    /// <param name="codepoint">The codepoint to encode.</param>
+    /// <param name="length">The length of the encoded data.</param>
+    /// <returns>The remaning region of <paramref name="target"/>.</returns>
+    public static Span<byte> Encode8(Span<byte> target, int codepoint, out int length)
+    {
+        var value = (uint)codepoint;
+        length = GetEncodedLength8(codepoint);
+        if (target.IsEmpty)
+            return target;
+
+        switch (length)
+        {
+            case 1:
+                target[0] = (byte)value;
+                return target[1..];
+            case 2:
+                target[0] = (byte)(0xC0 | ((value >> 6) & 0x1F));
+                target[1] = (byte)(0x80 | ((value >> 0) & 0x3F));
+                return target[2..];
+            case 3:
+                target[0] = (byte)(0xE0 | ((value >> 12) & 0x0F));
+                target[1] = (byte)(0x80 | ((value >> 6) & 0x3F));
+                target[2] = (byte)(0x80 | ((value >> 0) & 0x3F));
+                return target[3..];
+            case 4:
+                target[0] = (byte)(0xF0 | ((value >> 18) & 0x07));
+                target[1] = (byte)(0x80 | ((value >> 12) & 0x3F));
+                target[2] = (byte)(0x80 | ((value >> 6) & 0x3F));
+                target[3] = (byte)(0x80 | ((value >> 0) & 0x3F));
+                return target[4..];
+            case 5:
+                target[0] = (byte)(0xF8 | ((value >> 24) & 0x03));
+                target[1] = (byte)(0x80 | ((value >> 18) & 0x3F));
+                target[2] = (byte)(0x80 | ((value >> 12) & 0x3F));
+                target[3] = (byte)(0x80 | ((value >> 6) & 0x3F));
+                target[4] = (byte)(0x80 | ((value >> 0) & 0x3F));
+                return target[5..];
+            case 6:
+                target[0] = (byte)(0xFC | ((value >> 30) & 0x01));
+                target[1] = (byte)(0x80 | ((value >> 24) & 0x3F));
+                target[2] = (byte)(0x80 | ((value >> 18) & 0x3F));
+                target[3] = (byte)(0x80 | ((value >> 12) & 0x3F));
+                target[4] = (byte)(0x80 | ((value >> 6) & 0x3F));
+                target[5] = (byte)(0x80 | ((value >> 0) & 0x3F));
+                return target[6..];
+            case 7:
+                target[0] = 0xFE;
+                target[1] = (byte)(0x80 | ((value >> 30) & 0x03));
+                target[2] = (byte)(0x80 | ((value >> 24) & 0x3F));
+                target[3] = (byte)(0x80 | ((value >> 18) & 0x3F));
+                target[4] = (byte)(0x80 | ((value >> 12) & 0x3F));
+                target[5] = (byte)(0x80 | ((value >> 6) & 0x3F));
+                target[6] = (byte)(0x80 | ((value >> 0) & 0x3F));
+                return target[7..];
+            default:
+                Debug.Assert(false, $"{nameof(Length8)} property should have produced all possible cases.");
+                return target;
+        }
+    }
+
+    /// <summary>Encodes the codepoint to the target in UTF-16.</summary>
+    /// <param name="target">The target stream.</param>
+    /// <param name="codepoint">The codepoint to encode.</param>
+    /// <param name="be">Whether to use big endian.</param>
+    /// <returns>The length of the encoded data.</returns>
+    /// <remarks>Trims <paramref name="target"/> at beginning by the length.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int Encode16(Stream target, int codepoint, bool be)
+    {
+        Span<byte> buf = stackalloc byte[8];
+        Encode16(buf, codepoint, be, out var length);
+        target.Write(buf[..length]);
+        return length;
+    }
+
+    /// <summary>Encodes the codepoint to the target in UTF-16.</summary>
+    /// <param name="target">The target byte span.</param>
+    /// <param name="codepoint">The codepoint to encode.</param>
+    /// <param name="be">Whether to use big endian.</param>
+    /// <returns>The length of the encoded data.</returns>
+    /// <remarks>Trims <paramref name="target"/> at beginning by the length.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int Encode16(ref Span<byte> target, int codepoint, bool be)
+    {
+        target = Encode16(target, codepoint, be, out var length);
+        return length;
+    }
+
+    /// <summary>Encodes the codepoint to the target in UTF-16.</summary>
+    /// <param name="target">The optional target byte span.</param>
+    /// <param name="codepoint">The codepoint to encode.</param>
+    /// <param name="be">Whether to use big endian.</param>
+    /// <param name="length">The length of the encoded data.</param>
+    /// <returns>The remaning region of <paramref name="target"/>.</returns>
+    public static Span<byte> Encode16(Span<byte> target, int codepoint, bool be, out int length)
+    {
+        var value = (uint)codepoint;
+        length = GetEncodedLength16(codepoint);
+        if (target.IsEmpty)
+            return target;
+
+        if (be)
+        {
+            switch (length)
+            {
+                case 2:
+                    BinaryPrimitives.WriteUInt16BigEndian(target[0..], (ushort)value);
+                    return target[2..];
+                case 4:
+                    value -= 0x10000;
+                    BinaryPrimitives.WriteUInt16BigEndian(target[0..], (ushort)(0xD800 | ((value >> 10) & 0x3FF)));
+                    BinaryPrimitives.WriteUInt16BigEndian(target[2..], (ushort)(0xDC00 | ((value >> 00) & 0x3FF)));
+                    return target[4..];
+                case 6:
+                    value -= 0x10000;
+                    BinaryPrimitives.WriteUInt16BigEndian(target[0..], (ushort)(0xD800 | ((value >> 20) & 0x3FF)));
+                    BinaryPrimitives.WriteUInt16BigEndian(target[2..], (ushort)(0xDC00 | ((value >> 10) & 0x3FF)));
+                    BinaryPrimitives.WriteUInt16BigEndian(target[4..], (ushort)(0xDC00 | ((value >> 00) & 0x3FF)));
+                    return target[6..];
+                case 8:
+                    value -= 0x10000;
+                    BinaryPrimitives.WriteUInt16BigEndian(target[0..], (ushort)(0xD800 | ((value >> 30) & 0x3)));
+                    BinaryPrimitives.WriteUInt16BigEndian(target[2..], (ushort)(0xDC00 | ((value >> 20) & 0x3FF)));
+                    BinaryPrimitives.WriteUInt16BigEndian(target[4..], (ushort)(0xDC00 | ((value >> 10) & 0x3FF)));
+                    BinaryPrimitives.WriteUInt16BigEndian(target[6..], (ushort)(0xDC00 | ((value >> 00) & 0x3FF)));
+                    return target[8..];
+                default:
+                    Debug.Assert(false, $"{nameof(Length16)} property should have produced all possible cases.");
+                    return target;
+            }
+        }
+
+        switch (length)
+        {
+            case 2:
+                BinaryPrimitives.WriteUInt16LittleEndian(target[0..], (ushort)value);
+                return target[2..];
+            case 4:
+                value -= 0x10000;
+                BinaryPrimitives.WriteUInt16LittleEndian(target[0..], (ushort)(0xD800 | ((value >> 10) & 0x3FF)));
+                BinaryPrimitives.WriteUInt16LittleEndian(target[2..], (ushort)(0xDC00 | ((value >> 00) & 0x3FF)));
+                return target[4..];
+            case 6:
+                value -= 0x10000;
+                BinaryPrimitives.WriteUInt16LittleEndian(target[0..], (ushort)(0xD800 | ((value >> 20) & 0x3FF)));
+                BinaryPrimitives.WriteUInt16LittleEndian(target[2..], (ushort)(0xDC00 | ((value >> 10) & 0x3FF)));
+                BinaryPrimitives.WriteUInt16LittleEndian(target[4..], (ushort)(0xDC00 | ((value >> 00) & 0x3FF)));
+                return target[6..];
+            case 8:
+                value -= 0x10000;
+                BinaryPrimitives.WriteUInt16LittleEndian(target[0..], (ushort)(0xD800 | ((value >> 30) & 0x3)));
+                BinaryPrimitives.WriteUInt16LittleEndian(target[2..], (ushort)(0xDC00 | ((value >> 20) & 0x3FF)));
+                BinaryPrimitives.WriteUInt16LittleEndian(target[4..], (ushort)(0xDC00 | ((value >> 10) & 0x3FF)));
+                BinaryPrimitives.WriteUInt16LittleEndian(target[6..], (ushort)(0xDC00 | ((value >> 00) & 0x3FF)));
+                return target[8..];
+            default:
+                Debug.Assert(false, $"{nameof(Length16)} property should have produced all possible cases.");
+                return target;
+        }
+    }
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int CompareTo(UtfValue other) => IntValue.CompareTo(other.IntValue);
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool Equals(UtfValue other) => IntValue == other.IntValue;
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public override bool Equals(object? obj) => obj is UtfValue other && Equals(other);
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public override int GetHashCode() => IntValue;
+
+    /// <summary>Attempts to get the corresponding rune.</summary>
+    /// <param name="rune">The retrieved rune.</param>
+    /// <returns><c>true</c> if retrieved.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryGetRune(out Rune rune)
+    {
+        if (Rune.IsValid(IntValue))
+        {
+            rune = new(IntValue);
+            return true;
+        }
+
+        rune = default;
+        return false;
+    }
+
+    /// <summary>Encodes the codepoint to the target.</summary>
+    /// <param name="target">The target byte span.</param>
+    /// <returns>The remaning region of <paramref name="target"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Span<byte> Encode8(Span<byte> target) => Encode8(target, this, out _);
+}

--- a/src/Lumina/Text/UtfValue.cs
+++ b/src/Lumina/Text/UtfValue.cs
@@ -527,7 +527,7 @@ public readonly struct UtfValue : IEquatable<UtfValue>, IComparable<UtfValue>
     /// <param name="target">The optional target byte span.</param>
     /// <param name="codepoint">The codepoint to encode.</param>
     /// <param name="length">The length of the encoded data.</param>
-    /// <returns>The remaning region of <paramref name="target"/>.</returns>
+    /// <returns>The remaining region of <paramref name="target"/>.</returns>
     public static Span<byte> Encode8(Span<byte> target, int codepoint, out int length)
     {
         var value = (uint)codepoint;
@@ -618,7 +618,7 @@ public readonly struct UtfValue : IEquatable<UtfValue>, IComparable<UtfValue>
     /// <param name="codepoint">The codepoint to encode.</param>
     /// <param name="be">Whether to use big endian.</param>
     /// <param name="length">The length of the encoded data.</param>
-    /// <returns>The remaning region of <paramref name="target"/>.</returns>
+    /// <returns>The remaining region of <paramref name="target"/>.</returns>
     public static Span<byte> Encode16(Span<byte> target, int codepoint, bool be, out int length)
     {
         var value = (uint)codepoint;
@@ -720,7 +720,7 @@ public readonly struct UtfValue : IEquatable<UtfValue>, IComparable<UtfValue>
 
     /// <summary>Encodes the codepoint to the target.</summary>
     /// <param name="target">The target byte span.</param>
-    /// <returns>The remaning region of <paramref name="target"/>.</returns>
+    /// <returns>The remaining region of <paramref name="target"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Span<byte> Encode8(Span<byte> target) => Encode8(target, this, out _);
 }


### PR DESCRIPTION
* SeString.ToMacroString: Escape also `\` if the string is not being used as a string expression; otherwise, escape any of `[]()<>,\`.
* ReadOnlySeString/Payload/ExpressionSpan: Made it consistent with ToMacroString.

@pohky Mind testing this one? 