### PR TITLE
Support unknown macrocode in sestring spans and support ruby payload

### DIFF
--- a/src/Lumina/Text/Payloads/MacroCode.cs
+++ b/src/Lumina/Text/Payloads/MacroCode.cs
@@ -184,6 +184,13 @@ public enum MacroCode : byte
     /// <remarks>Parameters: row ID in UIColor sheet or 0 to pop(or reset?) the pushed color, terminator.</remarks>
     [MacroCodeData( null, "n x" )] EdgeColorType = 0x49,
 
+    /// <summary>Displays ruby text (furigana, interlinear annotation) above standard text.</summary>
+    /// <remarks>
+    /// <para>Parameters: standard text, ruby text.</para>
+    /// <para>Name of this payload is not defined in the client.</para>
+    /// </remarks>
+    [MacroCodeData(null, "s s")] Ruby = 0x4A,
+
     /// <summary>Adds a zero-padded number as text.</summary>
     /// <remarks>Parameters: integer expression, target length, terminator.</remarks>
     [MacroCodeData( null, "n n x" )] Digit = 0x50,

--- a/src/Lumina/Text/ReadOnly/ReadOnlySePayload.cs
+++ b/src/Lumina/Text/ReadOnly/ReadOnlySePayload.cs
@@ -40,8 +40,14 @@ public readonly struct ReadOnlySePayload : IEquatable< ReadOnlySePayload >, IRea
                     throw new ArgumentOutOfRangeException( nameof( macroCode ), macroCode, "MacroCode may not be defined if the payload is of text type." );
                 break;
             case ReadOnlySePayloadType.Macro:
-                if( !Enum.IsDefined( macroCode ) || macroCode == 0 )
-                    throw new ArgumentOutOfRangeException( nameof( macroCode ), macroCode, null );
+                if( macroCode == default )
+                    throw new ArgumentOutOfRangeException( nameof( macroCode ), macroCode, "MacroCode must be defined if the payload is of macro type." );
+                if( (byte) macroCode >= 0xCF )
+                {
+                    throw new ArgumentOutOfRangeException( nameof( macroCode ), macroCode,
+                        "Whether MacroCode is an integer expression is unknown. Change it when it happens." );
+                }
+
                 break;
             default:
                 throw new ArgumentOutOfRangeException( nameof( type ), type, null );

--- a/src/Lumina/Text/ReadOnly/ReadOnlySePayloadSpan.cs
+++ b/src/Lumina/Text/ReadOnly/ReadOnlySePayloadSpan.cs
@@ -39,8 +39,14 @@ public readonly ref struct ReadOnlySePayloadSpan
                     throw new ArgumentOutOfRangeException( nameof( macroCode ), macroCode, "MacroCode may not be defined if the payload is of text type." );
                 break;
             case ReadOnlySePayloadType.Macro:
-                if( !Enum.IsDefined( macroCode ) || macroCode == 0 )
-                    throw new ArgumentOutOfRangeException( nameof( macroCode ), macroCode, null );
+                if( macroCode == default )
+                    throw new ArgumentOutOfRangeException( nameof( macroCode ), macroCode, "MacroCode must be defined if the payload is of macro type." );
+                if( (byte) macroCode >= 0xCF )
+                {
+                    throw new ArgumentOutOfRangeException( nameof( macroCode ), macroCode,
+                        "Whether MacroCode is an integer expression is unknown. Change it when it happens." );
+                }
+
                 break;
             default:
                 throw new ArgumentOutOfRangeException( nameof( type ), type, null );


### PR DESCRIPTION
Not sure why I made unknown macrocode throw on payload span constructor, but yeah.