### PR TITLE
Add Xbox support

### DIFF
--- a/src/Lumina/Data/Structs/SqPackHeader.cs
+++ b/src/Lumina/Data/Structs/SqPackHeader.cs
@@ -10,7 +10,9 @@ namespace Lumina.Data.Structs
     {
         Win32,
         PS3,
-        PS4
+        PS4,
+        PS5,
+        Lys // Xbox
     }
     
     [StructLayout( LayoutKind.Sequential )]


### PR DESCRIPTION
The Xbox version of FFXIV (dumped with [Collateral Damage](https://github.com/exploits-forsale/collateral-damage)) uses the codename "Lysander", as evident by the PDB path and the dat format being XXXXXX.lys.dat0.

- Since this is a console release patched via Xbox Live, there is only one dat file per category and repository.
- Platform ID of 0x4 in the indexes. 0x3 is likely PS5.
- Files work out of the box since they seem to behave exactly like Win32. Thus, all that is required is a new enum entry.

I wanted to go with the name "Xbox" for the enum, but the file path is determined by the enum value, so I guess let's just hope people read that comment...

Pics or it didn't happen (ui/uld/BagStatus_hr1.tex):
![image](https://github.com/user-attachments/assets/bf2bb761-aeab-40ae-a905-5612cfb5276d)
