### PR TITLE
Copy over ReadColumn to RawSubrow

### DIFF
--- a/src/Lumina/Excel/RawSubrow.cs
+++ b/src/Lumina/Excel/RawSubrow.cs
@@ -34,6 +34,34 @@ public readonly struct RawSubrow( ExcelPage page, uint offset, uint row, ushort 
     public ushort GetColumnOffset( int columnIdx ) =>
         page.Sheet.GetColumnOffset( columnIdx );
 
+    /// <summary>
+    /// Reads the value of the specified column.
+    /// </summary>
+    /// <param name="columnIdx"></param>
+    /// <returns>Returns the value as a boxed <see langword="object"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the column is of an unknown type.</exception>
+    public object ReadColumn( int columnIdx )
+    {
+        var column = page.Sheet.Columns[columnIdx];
+        return column.Type switch
+        {
+            ExcelColumnDataType.String => ReadString( column.Offset ),
+            ExcelColumnDataType.Bool => ReadBool( column.Offset ),
+            ExcelColumnDataType.Int8 => ReadInt8( column.Offset ),
+            ExcelColumnDataType.UInt8 => ReadUInt8( column.Offset ),
+            ExcelColumnDataType.Int16 => ReadInt16( column.Offset ),
+            ExcelColumnDataType.UInt16 => ReadUInt16( column.Offset ),
+            ExcelColumnDataType.Int32 => ReadInt32( column.Offset ),
+            ExcelColumnDataType.UInt32 => ReadUInt32( column.Offset ),
+            ExcelColumnDataType.Float32 => ReadFloat32( column.Offset ),
+            ExcelColumnDataType.Int64 => ReadInt64( column.Offset ),
+            ExcelColumnDataType.UInt64 => ReadUInt64( column.Offset ),
+            >= ExcelColumnDataType.PackedBool0 and <= ExcelColumnDataType.PackedBool7 =>
+                page.ReadPackedBool( column.Offset, (byte)( column.Type - ExcelColumnDataType.PackedBool0 ) ),
+            _ => throw new InvalidOperationException( $"Unknown column type {column.Type}" )
+        };
+    }
+
     /// <inheritdoc cref="RawRow.ReadString(nuint)"/>
     public ReadOnlySeString ReadString( nuint offset ) =>
         page.ReadString( Offset + offset, Offset );


### PR DESCRIPTION
Copying the [RawRow.ReadColumn](https://github.com/NotAdam/Lumina/blob/master/src/Lumina/Excel/RawRow.cs#L44) function over to the RawSubrow struct.