### PR TITLE
Fix ReadColumn using wrong offset

### DIFF
--- a/src/Lumina/Excel/RawRow.cs
+++ b/src/Lumina/Excel/RawRow.cs
@@ -58,7 +58,7 @@ public readonly struct RawRow( ExcelPage page, uint offset, uint row ) : IExcelR
             ExcelColumnDataType.Int64 => ReadInt64( column.Offset ),
             ExcelColumnDataType.UInt64 => ReadUInt64( column.Offset ),
             >= ExcelColumnDataType.PackedBool0 and <= ExcelColumnDataType.PackedBool7 =>
-                page.ReadPackedBool( column.Offset, (byte)( column.Type - ExcelColumnDataType.PackedBool0 ) ),
+                ReadPackedBool( column.Offset, (byte)( column.Type - ExcelColumnDataType.PackedBool0 ) ),
             _ => throw new InvalidOperationException( $"Unknown column type {column.Type}" )
         };
     }

--- a/src/Lumina/Excel/RawSubrow.cs
+++ b/src/Lumina/Excel/RawSubrow.cs
@@ -57,7 +57,7 @@ public readonly struct RawSubrow( ExcelPage page, uint offset, uint row, ushort 
             ExcelColumnDataType.Int64 => ReadInt64( column.Offset ),
             ExcelColumnDataType.UInt64 => ReadUInt64( column.Offset ),
             >= ExcelColumnDataType.PackedBool0 and <= ExcelColumnDataType.PackedBool7 =>
-                page.ReadPackedBool( column.Offset, (byte)( column.Type - ExcelColumnDataType.PackedBool0 ) ),
+                ReadPackedBool( column.Offset, (byte)( column.Type - ExcelColumnDataType.PackedBool0 ) ),
             _ => throw new InvalidOperationException( $"Unknown column type {column.Type}" )
         };
     }


### PR DESCRIPTION
`page.ReadPackedBool` requires the complete Offset, so Field Offset + Row Offset.
`this.ReadPackedBool` provides the correct Field Offset, so it must have been simply an oversight calling `page.` here