### PR TITLE
More Uld fixes

### DIFF
--- a/src/Lumina/Data/Files/UldFile.cs
+++ b/src/Lumina/Data/Files/UldFile.cs
@@ -57,8 +57,8 @@ namespace Lumina.Data.Files
             for( var i = 0; i < TimelineList.ElementCount; i++ )
                 Timelines[ i ] = UldRoot.Timeline.Read( Reader );
 
-            var preSecondHeader = Reader.BaseStream.Position;
             Reader.Seek( basePos + CombineHeader.WidgetOffset );
+            var preSecondHeader = Reader.BaseStream.Position;
             SecondHeader = UldRoot.AtkHeader.Read( Reader );
 
             Reader.Seek( preSecondHeader + SecondHeader.WidgetOffset );

--- a/src/Lumina/Data/Parsing/Uld/NodeData.cs
+++ b/src/Lumina/Data/Parsing/Uld/NodeData.cs
@@ -628,7 +628,8 @@ namespace Lumina.Data.Parsing.Uld
             public int Max;
             public int Min;
             public int Add;
-            public uint Unk1;
+            public uint EndLetterId;
+            [Obsolete( "Renamed to EndLetterId" )] public uint Unk1;
             public bool Comma;
             public byte[] Unk2;
 
@@ -639,7 +640,8 @@ namespace Lumina.Data.Parsing.Uld
                 ret.Max = br.ReadInt32();
                 ret.Min = br.ReadInt32();
                 ret.Add = br.ReadInt32();
-                ret.Unk1 = br.ReadUInt32();
+                ret.EndLetterId = br.ReadUInt32();
+                ret.Unk1 = ret.EndLetterId;
                 ret.Comma = br.ReadBoolean();
                 ret.Unk2 = br.ReadBytes( 3 );
                 return ret;

--- a/src/Lumina/Data/Parsing/Uld/NodeData.cs
+++ b/src/Lumina/Data/Parsing/Uld/NodeData.cs
@@ -2,6 +2,8 @@
 // ReSharper disable NotAccessedField.Global
 // ReSharper disable NotAccessedField.Local
 // ReSharper disable MemberCanBePrivate.Global
+using System;
+
 namespace Lumina.Data.Parsing.Uld
 {
     public interface INode
@@ -80,7 +82,8 @@ namespace Lumina.Data.Parsing.Uld
             public short BottomOffset;
             public short LeftOffset;
             public short RightOffset;
-            public byte Unk1;
+            public byte BlendMode;
+            [Obsolete( "Renamed to BlendMode" )] public byte Unk1;
             public byte Unk2;
 
             public static NineGridNode Read( LuminaBinaryReader br )
@@ -94,7 +97,8 @@ namespace Lumina.Data.Parsing.Uld
                 ret.BottomOffset = br.ReadInt16();
                 ret.LeftOffset = br.ReadInt16();
                 ret.RightOffset = br.ReadInt16();
-                ret.Unk1 = br.ReadByte();
+                ret.BlendMode = br.ReadByte();
+                ret.Unk1 = ret.BlendMode;
                 ret.Unk2 = br.ReadByte();
                 return ret;
             }

--- a/src/Lumina/Data/Parsing/Uld/UldRoot.cs
+++ b/src/Lumina/Data/Parsing/Uld/UldRoot.cs
@@ -600,6 +600,8 @@ namespace Lumina.Data.Parsing.Uld
 
             public static Timeline Read( LuminaBinaryReader br )
             {
+                var pos = br.BaseStream.Position;
+
                 Timeline ret = new Timeline();
                 ret.Id = br.ReadUInt32();
                 ret.Offset = br.ReadUInt32();
@@ -609,6 +611,9 @@ namespace Lumina.Data.Parsing.Uld
                 ret.FrameData = new FrameData[ret.NumFrames];
                 for( int i = 0; i < ret.NumFrames; i++ )
                     ret.FrameData[ i ] = UldRoot.FrameData.Read( br );
+
+                br.BaseStream.Position = pos + ret.Offset;
+
                 return ret;
             }
         }

--- a/src/Lumina/Data/Parsing/Uld/UldRoot.cs
+++ b/src/Lumina/Data/Parsing/Uld/UldRoot.cs
@@ -128,7 +128,7 @@ namespace Lumina.Data.Parsing.Uld
                 ret.Id = br.ReadUInt32();
                 ret.Path = br.ReadChars( 44 );
                 ret.IconId = br.ReadUInt32();
-                if ( version >= 100 )
+                if ( version > 100 )
                 {
                     ret.ThemeSupportBitmask = br.ReadByte();
                     br.BaseStream.Position += 3;


### PR DESCRIPTION
- Fixed a mistake I made yesterday in the version check for TextureEntries.
- Fixed loading Timelines by skipping to the next entry. The game does it too. 🤷‍♂️
- Fixed loading some ulds by reading from the correct offset for the SecondHeader.
- Also updated node data structs based on fields in FFXIVClientStructs (using obsoletes this time 😉):
  - NineGridNode.Unk1 → BlendMode
  - NumericInputComponentNode.Unk1 → EndLetterId

---

These ulds can now be loaded without memory usage skyrocketing:
- ui/uld/CharaMake_Shadow.uld
- ui/uld/CharaSelect_Legacy.uld
- ui/uld/CharaSelect_Shadow.uld
- ui/uld/CharaSelect_Warning.uld
- ui/uld/CursorRect.uld
- ui/uld/GroupPoseFrame9grid001.uld
- ui/uld/GroupPoseFrame9grid002.uld
- ui/uld/GroupPoseFrame9grid003.uld
- ui/uld/GroupPoseGuide.uld
- ui/uld/HudLayoutBg.uld
- ui/uld/OperationGuide.uld
- ui/uld/ToolTipS.uld
- ui/uld/Warning.uld

And these 2 still can't be parsed, but I also won't be looking into that:
- ui/uld/convertimage_gcarmy_face.uld
- ui/uld/convertimage.uld