### PR TITLE
ReadOnlySeString updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,9 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '9.0.x'
     - name: Build with dotnet
       run: dotnet build --configuration Release --nologo ./src/Lumina.sln
     - name: dotnet test

--- a/src/Lumina.Tests/ReadOnlySeStringTests.cs
+++ b/src/Lumina.Tests/ReadOnlySeStringTests.cs
@@ -45,9 +45,11 @@ public class ReadOnlySeStringTests
     {
         var ss = ReadOnlySeString.Format( $"{_test}{_shy}{_ita1}{_test}{_hy}{_ita0}{_test}" );
         Assert.Equal( "TestTest-Test", ss.ToString() );
+        Assert.Equal( "TestTest-Test", ss.ToString( "t" ) );
         Assert.Equal( "Test\u00adTest-Test", ss.ToString( "y" ) );
         Assert.Equal( "Test<-><italic(1)>Test<--><italic(0)>Test", ss.ToString( "m" ) );
         Assert.Equal( "__TestTest-Test^^", $"__{ss}^^" );
+        Assert.Equal( "__TestTest-Test^^", $"__{ss:t}^^" );
         Assert.Equal( "__Test\u00adTest-Test^^", $"__{ss:y}^^" );
         Assert.Equal( "__Test<-><italic(1)>Test<--><italic(0)>Test^^", $"__{ss:m}^^" );
     }

--- a/src/Lumina.Tests/ReadOnlySeStringTests.cs
+++ b/src/Lumina.Tests/ReadOnlySeStringTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Lumina.Text.ReadOnly;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,8 +22,13 @@ public class ReadOnlySeStringTests
     [Fact]
     public void FormatTest()
     {
-        Assert.Equal( "Test<-><italic(1)>Test<--><italic(0)>Test",
-            ReadOnlySeString.Format( $"{_test}{_shy}{_ita1}{_test}{_hy}{_ita0}{_test}" ).ToMacroString() );
+        var ss = ReadOnlySeString.Format( $"{_test}{_shy}{_ita1}{_test}{_hy}{_ita0}{_test}" );
+        Assert.Equal( "Test<-><italic(1)>Test<--><italic(0)>Test", ss.ToMacroString() );
+        Assert.Equal( ss, ReadOnlySeString.Format( $"{ss}" ) );
+        Assert.Equal( ss, ReadOnlySeString.Format( $"{ss:r}" ) );
+        Assert.True( "TestTest-Test"u8.SequenceEqual( ReadOnlySeString.Format( $"{ss:t}" ) ) );
+        Assert.True( "Test\u00adTest-Test"u8.SequenceEqual( ReadOnlySeString.Format( $"{ss:y}" ) ) );
+        Assert.True( "Test<-><italic(1)>Test<--><italic(0)>Test"u8.SequenceEqual( ReadOnlySeString.Format( $"{ss:m}" ) ) );
     }
 
     [Fact]
@@ -41,5 +47,8 @@ public class ReadOnlySeStringTests
         Assert.Equal( "TestTest-Test", ss.ToString() );
         Assert.Equal( "Test\u00adTest-Test", ss.ToString( "y" ) );
         Assert.Equal( "Test<-><italic(1)>Test<--><italic(0)>Test", ss.ToString( "m" ) );
+        Assert.Equal( "__TestTest-Test^^", $"__{ss}^^" );
+        Assert.Equal( "__Test\u00adTest-Test^^", $"__{ss:y}^^" );
+        Assert.Equal( "__Test<-><italic(1)>Test<--><italic(0)>Test^^", $"__{ss:m}^^" );
     }
 }

--- a/src/Lumina.Tests/ReadOnlySeStringTests.cs
+++ b/src/Lumina.Tests/ReadOnlySeStringTests.cs
@@ -1,0 +1,45 @@
+using Lumina.Text.ReadOnly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Lumina.Tests;
+
+public class ReadOnlySeStringTests
+{
+    private readonly ITestOutputHelper _outputHelper;
+    private readonly ReadOnlySeString _test = ReadOnlySeString.FromMacroString( "Test" );
+    private readonly ReadOnlySeString _ita0 = ReadOnlySeString.FromMacroString( "<italic(0)>" );
+    private readonly ReadOnlySeString _ita1 = ReadOnlySeString.FromMacroString( "<italic(1)>" );
+    private readonly ReadOnlySeString _shy = ReadOnlySeString.FromMacroString( "<->" );
+    private readonly ReadOnlySeString _hy = ReadOnlySeString.FromMacroString( "<-->" );
+
+    public ReadOnlySeStringTests( ITestOutputHelper outputHelper )
+    {
+        _outputHelper = outputHelper;
+    }
+
+    [Fact]
+    public void FormatTest()
+    {
+        Assert.Equal( "Test<-><italic(1)>Test<--><italic(0)>Test",
+            ReadOnlySeString.Format( $"{_test}{_shy}{_ita1}{_test}{_hy}{_ita0}{_test}" ).ToMacroString() );
+    }
+
+    [Fact]
+    public void ExtractTextTest()
+    {
+        var ss = ReadOnlySeString.Format( $"{_test}{_shy}{_ita1}{_test}{_hy}{_ita0}{_test}" );
+        Assert.Equal( "TestTest-Test", ss.ExtractText() );
+        Assert.Equal( "Test\u00adTest-Test", ss.ExtractText( true ) );
+        Assert.Equal( "Test**Test-*Test", ss.ExtractText( false, "*" ) );
+    }
+
+    [Fact]
+    public void ToStringTest()
+    {
+        var ss = ReadOnlySeString.Format( $"{_test}{_shy}{_ita1}{_test}{_hy}{_ita0}{_test}" );
+        Assert.Equal( "TestTest-Test", ss.ToString() );
+        Assert.Equal( "Test\u00adTest-Test", ss.ToString( "y" ) );
+        Assert.Equal( "Test<-><italic(1)>Test<--><italic(0)>Test", ss.ToString( "m" ) );
+    }
+}

--- a/src/Lumina.Tests/SeStringBuilderTests.cs
+++ b/src/Lumina.Tests/SeStringBuilderTests.cs
@@ -295,7 +295,7 @@ public class SeStringBuilderTests
                 .PopColorType()
                 .PopEdgeColorType()
                 .ToReadOnlySeString();
-        _outputHelper.WriteLine( test.ToString() );
+        _outputHelper.WriteLine( test.ToMacroString() );
     }
 
     [Sheet( "Addon" )]
@@ -470,7 +470,7 @@ public class SeStringBuilderTests
             new SeStringBuilder()
                 .Append( $"Left:{0x1234,-8:X}\nRight:{0x1234,8:X}\n{test}\nint*: 0x{(void*) 0x12345678:X16}" )
                 .ToReadOnlySeString()
-                .ToString() );
+                .ToMacroString() );
     }
 
     [Fact]
@@ -482,7 +482,7 @@ public class SeStringBuilderTests
             new SeStringBuilder()
                 .Append( $"|{"Left",-8}|\n|{"Right"u8,8}|\n{boldHello}\n{(object) null}" )
                 .ToReadOnlySeString()
-                .ToString() );
+                .ToMacroString() );
     }
 
     [Fact]
@@ -492,7 +492,7 @@ public class SeStringBuilderTests
             new SeStringBuilder()
                 .Append( $"{"<italic(1)>test<italic(0)>":m}" )
                 .ToReadOnlySeString()
-                .ToString() );
+                .ToMacroString() );
 
     [Fact]
     public void ThrowsOnInvalidMacroStrings1() =>
@@ -529,7 +529,7 @@ public class SeStringBuilderTests
         {
             Assert.Equal(
                 $"{i}<string({i})>{i}<string(<string({i})>)>{i}",
-                ReadOnlySeString.FromMacroString( $"{i}<string({i})>{i}<string(<string({i})>)>{i}" ).ToString() );
+                ReadOnlySeString.FromMacroString( $"{i}<string({i})>{i}<string(<string({i})>)>{i}" ).ToMacroString() );
         }
     }
 
@@ -678,7 +678,7 @@ public class SeStringBuilderTests
                         ReadOnlySeString test2;
                         try
                         {
-                            test2 = ssb.Clear().AppendMacroString( test1.ToString() ).ToReadOnlySeString();
+                            test2 = ssb.Clear().AppendMacroString( test1.ToMacroString() ).ToReadOnlySeString();
                         }
                         catch( Exception e )
                         {

--- a/src/Lumina/Data/Language.cs
+++ b/src/Lumina/Data/Language.cs
@@ -14,7 +14,8 @@ namespace Lumina.Data
         French,
         ChineseSimplified,
         ChineseTraditional,
-        Korean
+        Korean,
+        ChineseTraditional2,
     }
 
     public class LanguageUtil
@@ -29,6 +30,7 @@ namespace Lumina.Data
             { Language.ChineseSimplified, "chs" },
             { Language.ChineseTraditional, "cht" },
             { Language.Korean, "ko" },
+            { Language.ChineseTraditional2, "tc" },
         };
 
         public static string GetLanguageStr( Language lang )

--- a/src/Lumina/Text/ReadOnly/ReadOnlySeStringSpan.cs
+++ b/src/Lumina/Text/ReadOnly/ReadOnlySeStringSpan.cs
@@ -324,9 +324,11 @@ public readonly ref struct ReadOnlySeStringSpan : IFormattable
     /// <inheritdoc/>
     public string ToString( string? format, IFormatProvider? formatProvider = null ) => format switch
     {
-        null or "" => ExtractText(),
+        null or "" or "t" => ExtractText(),
         "y" => ExtractText( true ),
         "m" => ToMacroString(),
+        "r" => throw new ArgumentOutOfRangeException( nameof( format ), format,
+            $"\"r\" is only supported in {nameof( SeStringBuilder.SeStringInterpolatedStringHandler )}." ),
         _ => throw new ArgumentOutOfRangeException( nameof( format ), format, "Unknown format." )
     };
 

--- a/src/Lumina/Text/ReadOnly/ReadOnlySeStringSpan.cs
+++ b/src/Lumina/Text/ReadOnly/ReadOnlySeStringSpan.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -11,7 +12,8 @@ namespace Lumina.Text.ReadOnly;
 
 /// <summary>A <see cref="string"/>-like immutable implementation of SeString.</summary>
 [SuppressMessage( "ReSharper", "ForeachCanBeConvertedToQueryUsingAnotherGetEnumerator", Justification = "Avoid heap allocation" )]
-public readonly ref struct ReadOnlySeStringSpan
+[DebuggerDisplay("{ToMacroString()}")]
+public readonly ref struct ReadOnlySeStringSpan : IFormattable
 {
     /// <summary>Read-only byte data for the SeString.</summary>
     public readonly ReadOnlySpan< byte > Data;
@@ -211,8 +213,17 @@ public readonly ref struct ReadOnlySeStringSpan
     /// <summary>Extracts the text contained in this instance of <see cref="ReadOnlySeStringSpan"/>, ignoring any payload that does not have a direct equivalent string
     /// representation.</summary>
     /// <returns>The extracted text.</returns>
-    public string ExtractText()
+    public string ExtractText() => ExtractText( false );
+
+    /// <summary>Extracts the text contained in this instance of <see cref="ReadOnlySeStringSpan"/>, ignoring any payload that does not have a direct equivalent string
+    /// representation.</summary>
+    /// <param name="useSoftHyphen">Whether to include soft hyphens.</param>
+    /// <param name="macroPlaceholder">Placeholder for macros that do not have direct text representations.</param>
+    /// <returns>The extracted text.</returns>
+    public string ExtractText( bool useSoftHyphen, string? macroPlaceholder = null )
     {
+        macroPlaceholder ??= "";
+
         var len = 0;
         foreach( var v in this )
         {
@@ -230,8 +241,11 @@ public readonly ref struct ReadOnlySeStringSpan
                             break;
                         case MacroCode.NonBreakingSpace:
                         case MacroCode.Hyphen:
-                        case MacroCode.SoftHyphen:
+                        case MacroCode.SoftHyphen when useSoftHyphen:
                             len += 1;
+                            break;
+                        default:
+                            len += macroPlaceholder.Length;
                             break;
                     }
 
@@ -268,9 +282,14 @@ public readonly ref struct ReadOnlySeStringSpan
                             bufspan = bufspan[ 1.. ];
                             break;
 
-                        case MacroCode.SoftHyphen:
+                        case MacroCode.SoftHyphen when useSoftHyphen:
                             bufspan[ 0 ] = '\u00AD';
                             bufspan = bufspan[ 1.. ];
+                            break;
+
+                        default:
+                            macroPlaceholder.CopyTo( bufspan );
+                            bufspan = bufspan[ macroPlaceholder.Length.. ];
                             break;
                     }
 
@@ -299,9 +318,21 @@ public readonly ref struct ReadOnlySeStringSpan
         return hc.ToHashCode();
     }
 
+    /// <inheritdoc/>
+    public override string ToString() => ToString( null );
+
+    /// <inheritdoc/>
+    public string ToString( string? format, IFormatProvider? formatProvider = null ) => format switch
+    {
+        null or "" => ExtractText(),
+        "y" => ExtractText( true ),
+        "m" => ToMacroString(),
+        _ => throw new ArgumentOutOfRangeException( nameof( format ), format, "Unknown format." )
+    };
+
     /// <summary>Gets the encodeable macro representation of this instance of <see cref="ReadOnlySeStringSpan"/>.</summary>
     /// <returns>The encodeable macro representation.</returns>
-    public override string ToString()
+    public string ToMacroString()
     {
         var sb = new StringBuilder();
         AppendMacroStringToStringBuilder( sb, false );

--- a/src/Lumina/Text/SeStringBuilder.InterpolatedStringHandler.cs
+++ b/src/Lumina/Text/SeStringBuilder.InterpolatedStringHandler.cs
@@ -616,9 +616,11 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( ReadOnlySeString value, int alignment, string? format )
         {
-            _ = format;
             var prevLen = Builder.GetStringStream().Length;
-            Builder.Append( value );
+            if( string.IsNullOrEmpty( format ) || format == "r" )
+                Builder.Append( value );
+            else
+                Builder.Append( value.ToString( format, _provider ) );
             FixAlignment( prevLen, alignment );
         }
 
@@ -634,9 +636,11 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( ReadOnlySeStringSpan value, int alignment, string? format )
         {
-            _ = format;
             var prevLen = Builder.GetStringStream().Length;
-            Builder.Append( value );
+            if( string.IsNullOrEmpty( format ) || format == "r" )
+                Builder.Append( value );
+            else
+                Builder.Append( value.ToString( format, _provider ) );
             FixAlignment( prevLen, alignment );
         }
 

--- a/src/Lumina/Text/SeStringBuilder.InterpolatedStringHandler.cs
+++ b/src/Lumina/Text/SeStringBuilder.InterpolatedStringHandler.cs
@@ -13,8 +13,26 @@ public sealed partial class SeStringBuilder
     [InterpolatedStringHandler]
     public readonly ref struct SeStringInterpolatedStringHandler
     {
-        private readonly SeStringBuilder _builder;
         private readonly IFormatProvider? _provider;
+
+        /// <summary>Initializes a new instance of the <see cref="SeStringInterpolatedStringHandler"/> struct.</summary>
+        /// <param name="literalLength">Number of characters in the literal.</param>
+        /// <param name="formattedCount">Number of formatted entries.</param>
+        [MethodImpl( MethodImplOptions.AggressiveInlining )]
+        [SuppressMessage( "ReSharper", "IntroduceOptionalParameters.Global", Justification = "InterpolatedStringHandlerArgument" )]
+        public SeStringInterpolatedStringHandler( int literalLength, int formattedCount )
+            : this( literalLength, formattedCount, SharedPool.Get(), null )
+        { }
+
+        /// <summary>Initializes a new instance of the <see cref="SeStringInterpolatedStringHandler"/> struct.</summary>
+        /// <param name="literalLength">Number of characters in the literal.</param>
+        /// <param name="formattedCount">Number of formatted entries.</param>
+        /// <param name="provider">Format provider.</param>
+        [MethodImpl( MethodImplOptions.AggressiveInlining )]
+        [SuppressMessage( "ReSharper", "IntroduceOptionalParameters.Global", Justification = "InterpolatedStringHandlerArgument" )]
+        public SeStringInterpolatedStringHandler( int literalLength, int formattedCount, IFormatProvider? provider )
+            : this( literalLength, formattedCount, SharedPool.Get(), provider )
+        { }
 
         /// <summary>Initializes a new instance of the <see cref="SeStringInterpolatedStringHandler"/> struct.</summary>
         /// <param name="literalLength">Number of characters in the literal.</param>
@@ -34,16 +52,19 @@ public sealed partial class SeStringBuilder
         [MethodImpl( MethodImplOptions.AggressiveInlining )]
         public SeStringInterpolatedStringHandler( int literalLength, int formattedCount, SeStringBuilder builder, IFormatProvider? provider )
         {
-            _builder = builder;
+            Builder = builder;
             _provider = provider;
             _ = formattedCount;
 
             builder.ReallocateStringSpan( builder.AllocateStringSpan( literalLength * 4 ).Length, 0 );
         }
 
+        /// <summary>Gets the instance of <see cref="SeStringBuilder"/> that this interpolator is writing to.</summary>
+        public SeStringBuilder Builder { get; }
+
         /// <summary>Writes the specified string to the handler.</summary>
         /// <param name="value">The string to write.</param>
-        public void AppendLiteral( string value ) => _builder.Append( value );
+        public void AppendLiteral( string value ) => Builder.Append( value );
 
         /// <summary>Writes the specified value to the handler.</summary>
         /// <param name="value">The value to write.</param>
@@ -69,7 +90,7 @@ public sealed partial class SeStringBuilder
         /// <typeparam name="T">The type of the value to write.</typeparam>
         public void AppendFormatted< T >( T value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             switch( value )
             {
                 case string s:
@@ -87,15 +108,15 @@ public sealed partial class SeStringBuilder
                     break;
 
                 case IFormattable f:
-                    _builder.Append( f.ToString( format, _provider ) );
+                    Builder.Append( f.ToString( format, _provider ) );
                     break;
 
                 case null:
-                    _builder.Append( "null"u8 );
+                    Builder.Append( "null"u8 );
                     break;
 
                 default:
-                    _builder.Append( value.ToString() );
+                    Builder.Append( value.ToString() );
                     break;
             }
 
@@ -115,8 +136,8 @@ public sealed partial class SeStringBuilder
         public void AppendFormatted( bool value, int alignment, string? format )
         {
             _ = format;
-            var prevLen = _builder.GetStringStream().Length;
-            _builder.Append( value ? "true"u8 : "false"u8 );
+            var prevLen = Builder.GetStringStream().Length;
+            Builder.Append( value ? "true"u8 : "false"u8 );
             FixAlignment( prevLen, alignment );
         }
 
@@ -132,7 +153,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( char value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -149,7 +170,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( byte value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -166,7 +187,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( ushort value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -183,7 +204,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( uint value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -200,7 +221,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( ulong value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -217,7 +238,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( nuint value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -234,7 +255,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( sbyte value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -251,7 +272,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( short value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -268,7 +289,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( int value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -285,7 +306,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( long value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -302,7 +323,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( nint value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -319,7 +340,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public unsafe void AppendFormatted( void* value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( (nint) value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -336,7 +357,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( Half value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -353,7 +374,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( float value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -370,7 +391,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( double value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -387,7 +408,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( scoped in decimal value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -404,7 +425,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( scoped in System.Numerics.BigInteger value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -421,7 +442,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( DateOnly value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -438,7 +459,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( TimeOnly value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -455,7 +476,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( TimeSpan value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -472,7 +493,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( DateTime value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -489,7 +510,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( DateTimeOffset value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -507,7 +528,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( scoped in System.Numerics.Complex value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -526,7 +547,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( scoped in UInt128 value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -543,7 +564,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( scoped in Int128 value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -560,7 +581,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( System.Net.IPAddress value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -577,7 +598,7 @@ public sealed partial class SeStringBuilder
         /// <inheritdoc cref="AppendFormatted{T}(T, int, string?)"/>
         public void AppendFormatted( System.Net.IPNetwork value, int alignment, string? format )
         {
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             AppendSpanFormattableAuto( value, format );
             FixAlignment( prevLen, alignment );
         }
@@ -596,8 +617,8 @@ public sealed partial class SeStringBuilder
         public void AppendFormatted( ReadOnlySeString value, int alignment, string? format )
         {
             _ = format;
-            var prevLen = _builder.GetStringStream().Length;
-            _builder.Append( value );
+            var prevLen = Builder.GetStringStream().Length;
+            Builder.Append( value );
             FixAlignment( prevLen, alignment );
         }
 
@@ -614,8 +635,8 @@ public sealed partial class SeStringBuilder
         public void AppendFormatted( ReadOnlySeStringSpan value, int alignment, string? format )
         {
             _ = format;
-            var prevLen = _builder.GetStringStream().Length;
-            _builder.Append( value );
+            var prevLen = Builder.GetStringStream().Length;
+            Builder.Append( value );
             FixAlignment( prevLen, alignment );
         }
 
@@ -632,8 +653,8 @@ public sealed partial class SeStringBuilder
         public void AppendFormatted( ReadOnlySePayload value, int alignment, string? format )
         {
             _ = format;
-            var prevLen = _builder.GetStringStream().Length;
-            _builder.Append( value );
+            var prevLen = Builder.GetStringStream().Length;
+            Builder.Append( value );
             FixAlignment( prevLen, alignment );
         }
 
@@ -650,8 +671,8 @@ public sealed partial class SeStringBuilder
         public void AppendFormatted( ReadOnlySePayloadSpan value, int alignment, string? format )
         {
             _ = format;
-            var prevLen = _builder.GetStringStream().Length;
-            _builder.Append( value );
+            var prevLen = Builder.GetStringStream().Length;
+            Builder.Append( value );
             FixAlignment( prevLen, alignment );
         }
 
@@ -672,8 +693,8 @@ public sealed partial class SeStringBuilder
         public void AppendFormatted( SeString value, int alignment, string? format )
         {
             _ = format;
-            var prevLen = _builder.GetStringStream().Length;
-            _builder.Append( value );
+            var prevLen = Builder.GetStringStream().Length;
+            Builder.Append( value );
             FixAlignment( prevLen, alignment );
         }
 
@@ -690,11 +711,11 @@ public sealed partial class SeStringBuilder
         public void AppendFormatted( ReadOnlySpan< byte > value, int alignment, string? format )
         {
             _ = format;
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             if( format?.StartsWith( 'm' ) is true )
-                _builder.AppendMacroString( value );
+                Builder.AppendMacroString( value );
             else
-                _builder.Append( value );
+                Builder.Append( value );
             FixAlignment( prevLen, alignment );
         }
 
@@ -711,11 +732,11 @@ public sealed partial class SeStringBuilder
         public void AppendFormatted( ReadOnlySpan< char > value, int alignment, string? format )
         {
             _ = format;
-            var prevLen = _builder.GetStringStream().Length;
+            var prevLen = Builder.GetStringStream().Length;
             if( format?.StartsWith( 'm' ) is true )
-                _builder.AppendMacroString( value );
+                Builder.AppendMacroString( value );
             else
-                _builder.Append( value );
+                Builder.Append( value );
             FixAlignment( prevLen, alignment );
         }
 
@@ -724,19 +745,19 @@ public sealed partial class SeStringBuilder
             if( alignment == 0 )
                 return;
 
-            var len = (int) ( _builder.GetStringStream().Length - prevLen );
+            var len = (int) ( Builder.GetStringStream().Length - prevLen );
             if( len >= Math.Abs( alignment ) )
                 return;
 
             if( alignment < 0 )
             {
                 // left align
-                _builder.AllocateStringSpan( -( len + alignment ) ).Fill( (byte) ' ' );
+                Builder.AllocateStringSpan( -( len + alignment ) ).Fill( (byte) ' ' );
             }
             else
             {
                 // right align
-                var span = _builder.ReallocateStringSpan( len, alignment );
+                var span = Builder.ReallocateStringSpan( len, alignment );
                 span[ ..len ].CopyTo( span[ ^len.. ] );
                 span[ ..^len ].Fill( (byte) ' ' );
             }
@@ -750,10 +771,10 @@ public sealed partial class SeStringBuilder
             var span = Span< byte >.Empty;
             for( var len = Unsafe.SizeOf< MemoryChunkStorage >(); len < Array.MaxLength >> 1; len *= 2 )
             {
-                span = _builder.ReallocateStringSpan( span.Length, len );
+                span = Builder.ReallocateStringSpan( span.Length, len );
                 if( value.TryFormat( span, out var written, format, _provider ) )
                 {
-                    _builder.ReallocateStringSpan( span.Length, written );
+                    Builder.ReallocateStringSpan( span.Length, written );
                     return;
                 }
             }
@@ -769,7 +790,7 @@ public sealed partial class SeStringBuilder
             var span = MemoryChunkStorage.AsSpanUninitialized< char >( out _ );
             if( value.TryFormat( span, out var written, format, _provider ) )
             {
-                _builder.Append( span[ ..written ] );
+                Builder.Append( span[ ..written ] );
                 return;
             }
 
@@ -778,7 +799,7 @@ public sealed partial class SeStringBuilder
                 var buf = ArrayPool< char >.Shared.Rent( len );
                 if( value.TryFormat( buf, out written, format, _provider ) )
                 {
-                    _builder.Append( buf[ ..written ] );
+                    Builder.Append( buf[ ..written ] );
                     ArrayPool< char >.Shared.Return( buf );
                     return;
                 }


### PR DESCRIPTION
* `ReadOnlySeString.ToString` and `ReadOnlySeStringSpan.ToString` now returns extracted text only without soft hyphens.
* `ReadOnlySeString.ToMacroString` and `ReadOnlySeStringSpan.ToMacroSpan` has been added.
* `ReadOnlySeString.ToString(string? format, IFormatProvider? formatProvider = null)` has been added. `formatProvider` is unused, and for `format`, empty string or `t` for text w/o SHY, `y` for text w/ SHY, and `m` for macro string is supported.
* `ReadOnlySeString.Format` has been added, which will accept a format string but will append `ReadOnlySeString/Span`s as-is without going through its string representation. Nothing at all, empty string or `r` can be specified for the ROSS' format to append it as-is, or `t`, `y`, or `m` to append it formatted.
* `Language.ChineseTraditional2` has been added.