### PR TITLE
Fix PcbResourceFile

### DIFF
--- a/src/Lumina/Data/Files/Pcb/PcbResourceFile.cs
+++ b/src/Lumina/Data/Files/Pcb/PcbResourceFile.cs
@@ -28,9 +28,6 @@ namespace Lumina.Data.Files.Pcb
                     TotalPolygons = reader.ReadUInt32()
                 };
 
-                if( header.TotalNodes == 0 )
-                    return header;
-
                 header.Children = new List< ResourceNode >();
 
                 var totalNodesRead = 0;

--- a/src/Lumina/Data/Files/Pcb/PcbResourceFile.cs
+++ b/src/Lumina/Data/Files/Pcb/PcbResourceFile.cs
@@ -100,9 +100,17 @@ namespace Lumina.Data.Files.Pcb
                     header.Vertices[ i ] = Common.Vector3.Read( reader );
                 }
 
+                var xFactor = Math.Abs((header.BoundingBox.Max.X - header.BoundingBox.Min.X) );
+                var yFactor = Math.Abs((header.BoundingBox.Max.Y - header.BoundingBox.Min.Y) );
+                var zFactor = Math.Abs((header.BoundingBox.Max.Z - header.BoundingBox.Min.Z) );
+
                 for( var i = numVertFloat32; i < numVertFloat32 + numVertFloat16; i++ )
                 {
-                    header.Vertices[ i ] = Common.Vector3.Read16( reader );
+                    var vertFloat16 = Common.Vector3.Read16( reader );
+                    vertFloat16.X = vertFloat16.X * xFactor + header.BoundingBox.Min.X;
+                    vertFloat16.Y = vertFloat16.Y * yFactor + header.BoundingBox.Min.Y;
+                    vertFloat16.Z = vertFloat16.Z * zFactor + header.BoundingBox.Min.Z;
+                    header.Vertices[ i ] = vertFloat16;
                 }
 
                 for( var i = 0; i < header.Polygons.Length; i++ )


### PR DESCRIPTION
1. Float 16 vertices are based on the bounding box dimensions and location ([Reference](https://github.com/SapphireServer/Sapphire/blob/bf3368224a00c180cbb7ba413b52395eba58ec0b/src/tools/pcb_reader/main.cpp#L375))
2. The count starts at 0 for whatever reason so there should be 1 resource node to read (Reference: `bg/ffxiv/sea_s1/twn/common/collision/s1t0_iw0_lip2.pcb`, https://github.com/SapphireServer/Sapphire/blob/bf3368224a00c180cbb7ba413b52395eba58ec0b/src/tools/pcb_reader/pcb.h#L12)