### PR TITLE
Add BC4 and BC6H texture formats

### DIFF
--- a/src/Lumina/Data/Files/TexFile.cs
+++ b/src/Lumina/Data/Files/TexFile.cs
@@ -110,7 +110,9 @@ namespace Lumina.Data.Files
             BC1 = 0x3420,
             BC2 = 0x3430,
             BC3 = 0x3431,
+            BC4 = 0x6120,
             BC5 = 0x6230,
+            BC6H = 0x6330,
             BC7 = 0x6432,
 
             // Depth stencil types


### PR DESCRIPTION
See also:
- https://github.com/aers/FFXIVClientStructs/blob/b41eccb6fd30bf714091853b8e04d1613c39229d/FFXIVClientStructs/FFXIV/Client/Graphics/Kernel/Texture.cs#L83-L85
- https://github.com/xivdev/Penumbra/blob/23c0506cb875f8613513f4169630eeb6549cc6ef/Penumbra/Import/Textures/TexFileParser.cs#L250-L252