### PR TITLE
Upgrade to .NET 10, expose ExcelPage and RowOffset

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,13 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v6.0.0
       with:
         fetch-depth: 0
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
     - name: Build with dotnet
       run: dotnet build --configuration Release --nologo ./src/Lumina.sln
     - name: dotnet test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,19 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v6.0.0
       with:
         fetch-depth: 0
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
     - name: Build with dotnet
       run: dotnet build --configuration Release --nologo ./src/Lumina.sln
     - name: dotnet test
       run: dotnet test --configuration Release --nologo ./src/Lumina.sln
     - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: Lumina-${{ matrix.os }}
         path: |

--- a/src/Lumina.Benchmark/ExcelRows.cs
+++ b/src/Lumina.Benchmark/ExcelRows.cs
@@ -5,6 +5,8 @@ namespace Lumina.Benchmark;
 [Sheet( "Addon" )]
 public readonly struct Addon( ExcelPage page, uint offset, uint row ) : IExcelRow< Addon >
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
     public uint Data => row & offset;
 
@@ -14,6 +16,8 @@ public readonly struct Addon( ExcelPage page, uint offset, uint row ) : IExcelRo
 [Sheet( "Item" )]
 public readonly struct Item( ExcelPage page, uint offset, uint row ) : IExcelRow< Item >
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
     public uint Data => row & offset;
 
@@ -25,6 +29,8 @@ public readonly struct Item( ExcelPage page, uint offset, uint row ) : IExcelRow
 [Sheet( "QuestLinkMarker" )]
 public readonly struct QuestLinkMarker( ExcelPage page, uint offset, uint row, ushort subrow ) : IExcelSubrow< QuestLinkMarker >
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
     public ushort SubrowId => subrow;
     public uint Data => row & offset;
@@ -36,6 +42,8 @@ public readonly struct QuestLinkMarker( ExcelPage page, uint offset, uint row, u
 [Sheet( "GatheringItem" )]
 public readonly struct GatheringItem( ExcelPage page, uint offset, uint row ) : IExcelRow< GatheringItem >
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
     public uint Data => row & offset;
 
@@ -49,6 +57,8 @@ public readonly struct GatheringItem( ExcelPage page, uint offset, uint row ) : 
 [Sheet( "EventItem" )]
 public readonly struct EventItem( ExcelPage page, uint offset, uint row ) : IExcelRow< EventItem >
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
     public uint Data => row & offset;
 
@@ -61,6 +71,8 @@ public readonly struct EventItem( ExcelPage page, uint offset, uint row ) : IExc
 [Sheet( "GatheringItemLevelConvertTable" )]
 public readonly struct GatheringItemLevelConvertTable( ExcelPage page, uint offset, uint row ) : IExcelRow< GatheringItemLevelConvertTable >
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
     public uint Data => row & offset;
 
@@ -73,6 +85,8 @@ public readonly struct GatheringItemLevelConvertTable( ExcelPage page, uint offs
 [Sheet( "ENpcBase" )]
 public readonly unsafe struct ENpcBase( ExcelPage page, uint offset, uint row ) : IExcelRow<ENpcBase>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     private static RowRef ENpcDataCtor( ExcelPage page, uint parentOffset, uint offset, uint i ) => RowRef.GetFirstValidRowOrUntyped( page.Module, page.ReadUInt32( offset + i * 4 ), [typeof( ChocoboTaxiStand ), typeof( CraftLeve ), typeof( CustomTalk ), typeof( DefaultTalk ), typeof( FccShop ), typeof( GCShop ), typeof( GilShop ), typeof( GuildleveAssignment ), typeof( GuildOrderGuide ), typeof( GuildOrderOfficer ), typeof( Quest ), typeof( SpecialShop ), typeof( Story ), typeof( SwitchTalk ), typeof( TopicSelect ), typeof( TripleTriad ), typeof( Warp )], 1, page.Language );
@@ -85,6 +99,8 @@ public readonly unsafe struct ENpcBase( ExcelPage page, uint offset, uint row ) 
 [Sheet( "ChocoboTaxiStand" )]
 public readonly struct ChocoboTaxiStand( ExcelPage page, uint offset, uint row ) : IExcelRow<ChocoboTaxiStand>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static ChocoboTaxiStand IExcelRow<ChocoboTaxiStand>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -94,6 +110,8 @@ public readonly struct ChocoboTaxiStand( ExcelPage page, uint offset, uint row )
 [Sheet( "CraftLeve" )]
 public readonly struct CraftLeve( ExcelPage page, uint offset, uint row ) : IExcelRow<CraftLeve>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static CraftLeve IExcelRow<CraftLeve>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -103,6 +121,8 @@ public readonly struct CraftLeve( ExcelPage page, uint offset, uint row ) : IExc
 [Sheet( "CustomTalk" )]
 public readonly struct CustomTalk( ExcelPage page, uint offset, uint row ) : IExcelRow<CustomTalk>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static CustomTalk IExcelRow<CustomTalk>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -112,6 +132,8 @@ public readonly struct CustomTalk( ExcelPage page, uint offset, uint row ) : IEx
 [Sheet( "DefaultTalk" )]
 public readonly struct DefaultTalk( ExcelPage page, uint offset, uint row ) : IExcelRow<DefaultTalk>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static DefaultTalk IExcelRow<DefaultTalk>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -121,6 +143,8 @@ public readonly struct DefaultTalk( ExcelPage page, uint offset, uint row ) : IE
 [Sheet( "FccShop" )]
 public readonly struct FccShop( ExcelPage page, uint offset, uint row ) : IExcelRow<FccShop>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static FccShop IExcelRow<FccShop>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -130,6 +154,8 @@ public readonly struct FccShop( ExcelPage page, uint offset, uint row ) : IExcel
 [Sheet( "GCShop" )]
 public readonly struct GCShop( ExcelPage page, uint offset, uint row ) : IExcelRow<GCShop>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static GCShop IExcelRow<GCShop>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -139,6 +165,8 @@ public readonly struct GCShop( ExcelPage page, uint offset, uint row ) : IExcelR
 [Sheet( "GilShop" )]
 public readonly struct GilShop( ExcelPage page, uint offset, uint row ) : IExcelRow<GilShop>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static GilShop IExcelRow<GilShop>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -148,6 +176,8 @@ public readonly struct GilShop( ExcelPage page, uint offset, uint row ) : IExcel
 [Sheet( "GuildleveAssignment" )]
 public readonly struct GuildleveAssignment( ExcelPage page, uint offset, uint row ) : IExcelRow<GuildleveAssignment>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static GuildleveAssignment IExcelRow<GuildleveAssignment>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -157,6 +187,8 @@ public readonly struct GuildleveAssignment( ExcelPage page, uint offset, uint ro
 [Sheet( "GuildOrderGuide" )]
 public readonly struct GuildOrderGuide( ExcelPage page, uint offset, uint row ) : IExcelRow<GuildOrderGuide>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static GuildOrderGuide IExcelRow<GuildOrderGuide>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -166,6 +198,8 @@ public readonly struct GuildOrderGuide( ExcelPage page, uint offset, uint row ) 
 [Sheet( "GuildOrderOfficer" )]
 public readonly struct GuildOrderOfficer( ExcelPage page, uint offset, uint row ) : IExcelRow<GuildOrderOfficer>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static GuildOrderOfficer IExcelRow<GuildOrderOfficer>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -175,6 +209,8 @@ public readonly struct GuildOrderOfficer( ExcelPage page, uint offset, uint row 
 [Sheet( "Quest" )]
 public readonly struct Quest( ExcelPage page, uint offset, uint row ) : IExcelRow<Quest>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static Quest IExcelRow<Quest>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -184,6 +220,8 @@ public readonly struct Quest( ExcelPage page, uint offset, uint row ) : IExcelRo
 [Sheet( "SpecialShop" )]
 public readonly struct SpecialShop( ExcelPage page, uint offset, uint row ) : IExcelRow<SpecialShop>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static SpecialShop IExcelRow<SpecialShop>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -193,6 +231,8 @@ public readonly struct SpecialShop( ExcelPage page, uint offset, uint row ) : IE
 [Sheet( "Story" )]
 public readonly struct Story( ExcelPage page, uint offset, uint row ) : IExcelRow<Story>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static Story IExcelRow<Story>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -202,6 +242,8 @@ public readonly struct Story( ExcelPage page, uint offset, uint row ) : IExcelRo
 [Sheet( "SwitchTalk" )]
 public readonly struct SwitchTalk( ExcelPage page, uint offset, uint row ) : IExcelRow<SwitchTalk>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static SwitchTalk IExcelRow<SwitchTalk>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -211,6 +253,8 @@ public readonly struct SwitchTalk( ExcelPage page, uint offset, uint row ) : IEx
 [Sheet( "TopicSelect" )]
 public readonly unsafe struct TopicSelect( ExcelPage page, uint offset, uint row ) : IExcelRow<TopicSelect>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     private static RowRef ShopCtor( ExcelPage page, uint parentOffset, uint offset, uint i ) => RowRef.GetFirstValidRowOrUntyped( page.Module, page.ReadUInt32( offset + 4 + i * 4 ), [typeof( SpecialShop ), typeof( GilShop ), typeof( PreHandler )], 2, page.Language );
@@ -223,6 +267,8 @@ public readonly unsafe struct TopicSelect( ExcelPage page, uint offset, uint row
 [Sheet( "TripleTriad" )]
 public readonly struct TripleTriad( ExcelPage page, uint offset, uint row ) : IExcelRow<TripleTriad>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static TripleTriad IExcelRow<TripleTriad>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -232,6 +278,8 @@ public readonly struct TripleTriad( ExcelPage page, uint offset, uint row ) : IE
 [Sheet( "Warp" )]
 public readonly struct Warp( ExcelPage page, uint offset, uint row ) : IExcelRow<Warp>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static Warp IExcelRow<Warp>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -241,6 +289,8 @@ public readonly struct Warp( ExcelPage page, uint offset, uint row ) : IExcelRow
 [Sheet( "PreHandler" )]
 public readonly struct PreHandler( ExcelPage page, uint offset, uint row ) : IExcelRow<PreHandler>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     public readonly RowRef Target => RowRef.GetFirstValidRowOrUntyped( page.Module, page.ReadUInt32( offset + 8 ), [typeof( CollectablesShop ), typeof( InclusionShop ), typeof( GilShop ), typeof( SpecialShop ), typeof( Description )], 3, page.Language );
@@ -252,6 +302,8 @@ public readonly struct PreHandler( ExcelPage page, uint offset, uint row ) : IEx
 [Sheet( "CollectablesShop" )]
 public readonly struct CollectablesShop( ExcelPage page, uint offset, uint row ) : IExcelRow<CollectablesShop>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static CollectablesShop IExcelRow<CollectablesShop>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -261,6 +313,8 @@ public readonly struct CollectablesShop( ExcelPage page, uint offset, uint row )
 [Sheet( "InclusionShop" )]
 public readonly struct InclusionShop( ExcelPage page, uint offset, uint row ) : IExcelRow<InclusionShop>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static InclusionShop IExcelRow<InclusionShop>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -270,6 +324,8 @@ public readonly struct InclusionShop( ExcelPage page, uint offset, uint row ) : 
 [Sheet( "Description" )]
 public readonly struct Description( ExcelPage page, uint offset, uint row ) : IExcelRow<Description>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static Description IExcelRow<Description>.Create( ExcelPage page, uint offset, uint row ) =>

--- a/src/Lumina.Benchmark/Lumina.Benchmark.csproj
+++ b/src/Lumina.Benchmark/Lumina.Benchmark.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <OutputType>Exe</OutputType>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
@@ -9,9 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
-        <PackageReference Include="BenchmarkDotNet.Diagnostics.dotTrace" Version="0.13.10" />
-        <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.10" />
+        <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+        <PackageReference Include="BenchmarkDotNet.Diagnostics.dotTrace" Version="0.15.8" />
+        <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
         <ProjectReference Include="..\Lumina\Lumina.csproj" />
     </ItemGroup>
 

--- a/src/Lumina.Cmd/Commands/ExcelUpdate.cs
+++ b/src/Lumina.Cmd/Commands/ExcelUpdate.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using CliFx;
 using CliFx.Attributes;
+using CliFx.Infrastructure;
 using Lumina.Data.Files.Excel;
 
 namespace Lumina.Cmd.Commands

--- a/src/Lumina.Cmd/Commands/FileDiff.cs
+++ b/src/Lumina.Cmd/Commands/FileDiff.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Threading.Tasks;
 using CliFx;
 using CliFx.Attributes;
+using CliFx.Infrastructure;
 
 namespace Lumina.Cmd.Commands
 {

--- a/src/Lumina.Cmd/Commands/FileExtract.cs
+++ b/src/Lumina.Cmd/Commands/FileExtract.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using CliFx;
 using CliFx.Attributes;
+using CliFx.Infrastructure;
 
 namespace Lumina.Cmd.Commands
 {
@@ -13,7 +14,7 @@ namespace Lumina.Cmd.Commands
         [CommandOption( "dataPath", 'p',
             Description = "Path to the client sqpack folder",
             IsRequired = true,
-            EnvironmentVariableName = "LUMINA_CMD_CLIENT_PATH" )]
+            EnvironmentVariable = "LUMINA_CMD_CLIENT_PATH" )]
         public string Path { get; set; }
 
         [CommandOption( "outputPath", 'o',

--- a/src/Lumina.Cmd/Commands/FileInfo.cs
+++ b/src/Lumina.Cmd/Commands/FileInfo.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Threading.Tasks;
 using CliFx;
 using CliFx.Attributes;
+using CliFx.Infrastructure;
 using Lumina.Data;
 using Lumina.Data.Files;
 using Lumina.Data.Files.Excel;
@@ -17,7 +18,7 @@ namespace Lumina.Cmd.Commands
         [CommandOption( "dataPath", 'p',
             Description = "Path to the client sqpack folder",
             IsRequired = true,
-            EnvironmentVariableName = "LUMINA_CMD_CLIENT_PATH" )]
+            EnvironmentVariable = "LUMINA_CMD_CLIENT_PATH" )]
         public string DataPath { get; set; }
 
         private FileResource LoadResource( GameData gameData, string path )

--- a/src/Lumina.Cmd/Commands/Repo.cs
+++ b/src/Lumina.Cmd/Commands/Repo.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using CliFx;
 using CliFx.Attributes;
+using CliFx.Infrastructure;
 using Lumina.Data;
 
 namespace Lumina.Cmd.Commands
@@ -12,7 +13,7 @@ namespace Lumina.Cmd.Commands
         [CommandOption( "dataPath", 'p',
             Description = "Path to the client sqpack folder",
             IsRequired = true,
-            EnvironmentVariableName = "LUMINA_CMD_CLIENT_PATH" )]
+            EnvironmentVariable = "LUMINA_CMD_CLIENT_PATH" )]
         public string DataPath { get; set; }
 
         public ValueTask ExecuteAsync( IConsole console )

--- a/src/Lumina.Cmd/Lumina.Cmd.csproj
+++ b/src/Lumina.Cmd/Lumina.Cmd.csproj
@@ -2,12 +2,12 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="CliFx" Version="1.0.0" />
-      <PackageReference Include="Pastel" Version="1.3.1" />
+      <PackageReference Include="CliFx" Version="2.3.6" />
+      <PackageReference Include="Pastel" Version="7.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Lumina.Cmd/Program.cs
+++ b/src/Lumina.Cmd/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using CliFx;
 
 namespace Lumina.Cmd
@@ -10,7 +10,7 @@ namespace Lumina.Cmd
             Pastel.ConsoleExtensions.Enable();
             
             return await new CliApplicationBuilder()
-                .UseDescription( "A command line tool that probably does useful things." )
+                .SetDescription( "A command line tool that probably does useful things." )
                 .AddCommandsFromThisAssembly()
                 .Build()
                 .RunAsync();

--- a/src/Lumina.Example/Condition.cs
+++ b/src/Lumina.Example/Condition.cs
@@ -1,25 +1,16 @@
-using Lumina.Data;
 using Lumina.Excel;
 
-namespace Lumina.Example
+namespace Lumina.Example;
+
+[Sheet( "Condition" )]
+readonly public struct Condition( ExcelPage page, uint offset, uint row ) : IExcelRow<Condition>
 {
-    [Sheet( "Condition" )]
-    public class Condition : ExcelRow
-    {
-        public int Index;
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
+    public uint RowId => row;
 
-        public uint LogMessageId;
+    public readonly RowRef<LogMessage> LogMessage => new( page.Module, page.ReadUInt32( offset ), page.Language );
 
-        public LazyRow< LogMessage > LogMessage;
-
-        public override void PopulateData( RowParser parser, GameData gameData, Language language )
-        {
-            base.PopulateData( parser, gameData, language );
-
-            Index = parser.ReadColumn< int >( 0 );
-
-            LogMessageId = parser.ReadColumn< uint >( 2 );
-            LogMessage = new LazyRow< LogMessage >( gameData, LogMessageId, language );
-        }
-    }
+    static Condition IExcelRow<Condition>.Create( ExcelPage page, uint offset, uint row ) =>
+        new( page, offset, row );
 }

--- a/src/Lumina.Example/LogMessage.cs
+++ b/src/Lumina.Example/LogMessage.cs
@@ -1,18 +1,17 @@
-using Lumina.Data;
 using Lumina.Excel;
+using Lumina.Text.ReadOnly;
 
-namespace Lumina.Example
+namespace Lumina.Example;
+
+[Sheet( "LogMessage" )]
+readonly public struct LogMessage( ExcelPage page, uint offset, uint row ) : IExcelRow<LogMessage>
 {
-    [Sheet( "LogMessage" )]
-    public class LogMessage : ExcelRow
-    {
-        public string Text;
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
+    public uint RowId => row;
 
-        public override void PopulateData( RowParser parser, GameData gameData, Language language )
-        {
-            base.PopulateData( parser, gameData, language );
+    public readonly ReadOnlySeString Text => page.ReadString( offset, offset );
 
-            Text = parser.ReadColumn< string >( 4 );
-        }
-    }
+    static LogMessage IExcelRow<LogMessage>.Create( ExcelPage page, uint offset, uint row ) =>
+        new( page, offset, row );
 }

--- a/src/Lumina.Example/Lumina.Example.csproj
+++ b/src/Lumina.Example/Lumina.Example.csproj
@@ -2,13 +2,13 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Lumina" Version="3.10.0" />
-      <PackageReference Include="Lumina.Excel" Version="6.3.2" />
+      <PackageReference Include="Lumina" Version="6.7.0" />
+      <PackageReference Include="Lumina.Excel" Version="7.3.1" />
     </ItemGroup>
 
 </Project>

--- a/src/Lumina.Tests/ExcelRows.cs
+++ b/src/Lumina.Tests/ExcelRows.cs
@@ -7,6 +7,8 @@ namespace Lumina.Tests;
 [Sheet( "ENpcBase" )]
 public readonly unsafe struct ENpcBase( ExcelPage page, uint offset, uint row ) : IExcelRow<ENpcBase>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     private static uint ENpcDataCtor( ExcelPage page, uint parentOffset, uint offset, uint i ) => page.ReadUInt32( offset + i * 4 );
@@ -22,6 +24,8 @@ public readonly unsafe struct ENpcBase( ExcelPage page, uint offset, uint row ) 
 [Sheet( "ChocoboTaxiStand" )]
 public readonly struct ChocoboTaxiStand( ExcelPage page, uint offset, uint row ) : IExcelRow<ChocoboTaxiStand>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static ChocoboTaxiStand IExcelRow<ChocoboTaxiStand>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -31,6 +35,8 @@ public readonly struct ChocoboTaxiStand( ExcelPage page, uint offset, uint row )
 [Sheet( "CraftLeve" )]
 public readonly struct CraftLeve( ExcelPage page, uint offset, uint row ) : IExcelRow<CraftLeve>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static CraftLeve IExcelRow<CraftLeve>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -40,6 +46,8 @@ public readonly struct CraftLeve( ExcelPage page, uint offset, uint row ) : IExc
 [Sheet( "CustomTalk" )]
 public readonly struct CustomTalk( ExcelPage page, uint offset, uint row ) : IExcelRow<CustomTalk>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static CustomTalk IExcelRow<CustomTalk>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -49,6 +57,8 @@ public readonly struct CustomTalk( ExcelPage page, uint offset, uint row ) : IEx
 [Sheet( "DefaultTalk" )]
 public readonly struct DefaultTalk( ExcelPage page, uint offset, uint row ) : IExcelRow<DefaultTalk>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static DefaultTalk IExcelRow<DefaultTalk>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -58,6 +68,8 @@ public readonly struct DefaultTalk( ExcelPage page, uint offset, uint row ) : IE
 [Sheet( "FccShop" )]
 public readonly struct FccShop( ExcelPage page, uint offset, uint row ) : IExcelRow<FccShop>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static FccShop IExcelRow<FccShop>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -67,6 +79,8 @@ public readonly struct FccShop( ExcelPage page, uint offset, uint row ) : IExcel
 [Sheet( "GCShop" )]
 public readonly struct GCShop( ExcelPage page, uint offset, uint row ) : IExcelRow<GCShop>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static GCShop IExcelRow<GCShop>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -76,6 +90,8 @@ public readonly struct GCShop( ExcelPage page, uint offset, uint row ) : IExcelR
 [Sheet( "GilShop" )]
 public readonly struct GilShop( ExcelPage page, uint offset, uint row ) : IExcelRow<GilShop>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static GilShop IExcelRow<GilShop>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -85,6 +101,8 @@ public readonly struct GilShop( ExcelPage page, uint offset, uint row ) : IExcel
 [Sheet( "GuildleveAssignment" )]
 public readonly struct GuildleveAssignment( ExcelPage page, uint offset, uint row ) : IExcelRow<GuildleveAssignment>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static GuildleveAssignment IExcelRow<GuildleveAssignment>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -94,6 +112,8 @@ public readonly struct GuildleveAssignment( ExcelPage page, uint offset, uint ro
 [Sheet( "GuildOrderGuide" )]
 public readonly struct GuildOrderGuide( ExcelPage page, uint offset, uint row ) : IExcelRow<GuildOrderGuide>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static GuildOrderGuide IExcelRow<GuildOrderGuide>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -103,6 +123,8 @@ public readonly struct GuildOrderGuide( ExcelPage page, uint offset, uint row ) 
 [Sheet( "GuildOrderOfficer" )]
 public readonly struct GuildOrderOfficer( ExcelPage page, uint offset, uint row ) : IExcelRow<GuildOrderOfficer>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static GuildOrderOfficer IExcelRow<GuildOrderOfficer>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -112,6 +134,8 @@ public readonly struct GuildOrderOfficer( ExcelPage page, uint offset, uint row 
 [Sheet( "Quest" )]
 public readonly struct Quest( ExcelPage page, uint offset, uint row ) : IExcelRow<Quest>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static Quest IExcelRow<Quest>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -121,6 +145,8 @@ public readonly struct Quest( ExcelPage page, uint offset, uint row ) : IExcelRo
 [Sheet( "SpecialShop" )]
 public readonly struct SpecialShop( ExcelPage page, uint offset, uint row ) : IExcelRow<SpecialShop>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static SpecialShop IExcelRow<SpecialShop>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -130,6 +156,8 @@ public readonly struct SpecialShop( ExcelPage page, uint offset, uint row ) : IE
 [Sheet( "Story" )]
 public readonly struct Story( ExcelPage page, uint offset, uint row ) : IExcelRow<Story>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static Story IExcelRow<Story>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -139,6 +167,8 @@ public readonly struct Story( ExcelPage page, uint offset, uint row ) : IExcelRo
 [Sheet( "SwitchTalk" )]
 public readonly struct SwitchTalk( ExcelPage page, uint offset, uint row ) : IExcelRow<SwitchTalk>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static SwitchTalk IExcelRow<SwitchTalk>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -148,6 +178,8 @@ public readonly struct SwitchTalk( ExcelPage page, uint offset, uint row ) : IEx
 [Sheet( "TopicSelect" )]
 public readonly unsafe struct TopicSelect( ExcelPage page, uint offset, uint row ) : IExcelRow<TopicSelect>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     private static RowRef ShopCtor( ExcelPage page, uint parentOffset, uint offset, uint i ) => RowRef.GetFirstValidRowOrUntyped( page.Module, page.ReadUInt32( offset + 4 + i * 4 ), [typeof( SpecialShop ), typeof( GilShop ), typeof( PreHandler )], 2 );
@@ -160,6 +192,8 @@ public readonly unsafe struct TopicSelect( ExcelPage page, uint offset, uint row
 [Sheet( "TripleTriad" )]
 public readonly struct TripleTriad( ExcelPage page, uint offset, uint row ) : IExcelRow<TripleTriad>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static TripleTriad IExcelRow<TripleTriad>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -169,6 +203,8 @@ public readonly struct TripleTriad( ExcelPage page, uint offset, uint row ) : IE
 [Sheet( "Warp" )]
 public readonly struct Warp( ExcelPage page, uint offset, uint row ) : IExcelRow<Warp>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static Warp IExcelRow<Warp>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -178,6 +214,8 @@ public readonly struct Warp( ExcelPage page, uint offset, uint row ) : IExcelRow
 [Sheet( "PreHandler" )]
 public readonly struct PreHandler( ExcelPage page, uint offset, uint row ) : IExcelRow<PreHandler>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     public readonly RowRef Target => RowRef.GetFirstValidRowOrUntyped( page.Module, page.ReadUInt32( offset + 8 ), [typeof( CollectablesShop ), typeof( InclusionShop ), typeof( GilShop ), typeof( SpecialShop ), typeof( Description )], 3 );
@@ -189,6 +227,8 @@ public readonly struct PreHandler( ExcelPage page, uint offset, uint row ) : IEx
 [Sheet( "CollectablesShop" )]
 public readonly struct CollectablesShop( ExcelPage page, uint offset, uint row ) : IExcelRow<CollectablesShop>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static CollectablesShop IExcelRow<CollectablesShop>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -198,6 +238,8 @@ public readonly struct CollectablesShop( ExcelPage page, uint offset, uint row )
 [Sheet( "InclusionShop" )]
 public readonly struct InclusionShop( ExcelPage page, uint offset, uint row ) : IExcelRow<InclusionShop>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static InclusionShop IExcelRow<InclusionShop>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -207,6 +249,8 @@ public readonly struct InclusionShop( ExcelPage page, uint offset, uint row ) : 
 [Sheet( "Description" )]
 public readonly struct Description( ExcelPage page, uint offset, uint row ) : IExcelRow<Description>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     static Description IExcelRow<Description>.Create( ExcelPage page, uint offset, uint row ) =>
@@ -216,6 +260,8 @@ public readonly struct Description( ExcelPage page, uint offset, uint row ) : IE
 [Sheet( "GatheringPointBase" )]
 public readonly unsafe struct GatheringPointBase( ExcelPage page, uint offset, uint row ) : IExcelRow<GatheringPointBase>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     public readonly RowRef<GatheringType> GatheringType => new( page.Module, (uint)page.ReadInt32( offset ), page.Language );
@@ -227,6 +273,8 @@ public readonly unsafe struct GatheringPointBase( ExcelPage page, uint offset, u
 [Sheet( "GatheringType" )]
 public readonly struct GatheringType( ExcelPage page, uint offset, uint row ) : IExcelRow<GatheringType>
 {
+    public ExcelPage ExcelPage => page;
+    public uint RowOffset => offset;
     public uint RowId => row;
 
     public readonly ReadOnlySeString Name => page.ReadString( offset, offset );

--- a/src/Lumina.Tests/Lumina.Tests.csproj
+++ b/src/Lumina.Tests/Lumina.Tests.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-        <PackageReference Include="xunit" Version="2.4.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-        <PackageReference Include="coverlet.collector" Version="1.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+        <PackageReference Include="coverlet.collector" Version="6.0.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Lumina.Tests/SeStringBuilderTests.cs
+++ b/src/Lumina.Tests/SeStringBuilderTests.cs
@@ -301,6 +301,8 @@ public class SeStringBuilderTests
     [Sheet( "Addon" )]
     public readonly struct Addon( ExcelPage page, uint offset, uint row ) : IExcelRow< Addon >
     {
+        public ExcelPage ExcelPage => page;
+        public uint RowOffset => offset;
         public uint RowId => row;
 
         public ReadOnlySeString Text => page.ReadString( offset, offset );
@@ -695,6 +697,8 @@ public class SeStringBuilderTests
     [Sheet]
     public readonly struct RawRow( ExcelPage page, uint offset, uint row ) : IExcelRow< RawRow >
     {
+        public ExcelPage ExcelPage => page;
+        public uint RowOffset => offset;
         public uint RowId => row;
 
         public ReadOnlySeString ReadString( ushort off ) =>

--- a/src/Lumina/Data/LuminaBinaryReader.cs
+++ b/src/Lumina/Data/LuminaBinaryReader.cs
@@ -173,7 +173,7 @@ namespace Lumina.Data
         private T[] ReadPrimitiveArray< T >( int count ) where T : struct
         {
             var size = Unsafe.SizeOf< T >();
-            var span = MemoryMarshal.Cast< byte, T >( ReadBytes( count * size ) );
+            var span = MemoryMarshal.Cast< byte, T >( ReadBytes( count * size ).AsSpan() );
 
             if( ConvertEndianness )
             {

--- a/src/Lumina/Excel/IExcelRow.cs
+++ b/src/Lumina/Excel/IExcelRow.cs
@@ -6,6 +6,12 @@ namespace Lumina.Excel;
 /// <typeparam name="T">The type that implements the interface.</typeparam>
 public interface IExcelRow< out T > where T : struct
 {
+    /// <summary>The associated <see cref="Excel.ExcelPage"/> of the row.</summary>
+    public ExcelPage ExcelPage { get; }
+
+    /// <summary>Offset to the referenced row in the <see cref="Excel.ExcelPage"/>.</summary>
+    public uint RowOffset { get; }
+
     /// <summary>Gets the row ID.</summary>
     uint RowId { get; }
 

--- a/src/Lumina/Excel/IExcelSubrow.cs
+++ b/src/Lumina/Excel/IExcelSubrow.cs
@@ -6,6 +6,12 @@ namespace Lumina.Excel;
 /// <typeparam name="T">The type that implements the interface.</typeparam>
 public interface IExcelSubrow< out T > where T : struct
 {
+    /// <summary>The associated <see cref="Excel.ExcelPage"/> of the row.</summary>
+    public ExcelPage ExcelPage { get; }
+
+    /// <summary>Offset to the referenced row in the <see cref="Excel.ExcelPage"/>.</summary>
+    public uint RowOffset { get; }
+
     /// <summary>Gets the row ID.</summary>
     uint RowId { get; }
 

--- a/src/Lumina/Excel/RawRow.cs
+++ b/src/Lumina/Excel/RawRow.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace Lumina.Excel;
 
 /// <summary>
-/// An <see cref="IExcelRow{T}"/> type for explicitly reading data from an <see cref="ExcelPage"/>.
+/// An <see cref="IExcelRow{T}"/> type for explicitly reading data from an <see cref="Excel.ExcelPage"/>.
 /// </summary>
 /// <remarks>
 /// This type is designed to be used to read from arbitrary columns and offsets.
@@ -14,15 +14,11 @@ namespace Lumina.Excel;
 [Sheet]
 public readonly struct RawRow( ExcelPage page, uint offset, uint row ) : IExcelRow<RawRow>
 {
-    /// <summary>
-    /// The associated <see cref="ExcelPage"/> of the row.
-    /// </summary>
-    public ExcelPage Page => page;
+    /// <inheritdoc/>
+    public ExcelPage ExcelPage => page;
 
-    /// <summary>
-    /// Offset to the referenced row in the <see cref="Page"/>.
-    /// </summary>
-    public uint Offset => offset;
+    /// <inheritdoc/>
+    public uint RowOffset => offset;
 
     /// <inheritdoc/>
     public uint RowId => row;
@@ -69,7 +65,7 @@ public readonly struct RawRow( ExcelPage page, uint offset, uint row ) : IExcelR
     /// <param name="offset">Offset of the field inside the row.</param>
     /// <inheritdoc cref="ExcelPage.ReadString(nuint, nuint)"/>
     public ReadOnlySeString ReadString( nuint offset ) =>
-        page.ReadString( Offset + offset, Offset );
+        page.ReadString( RowOffset + offset, RowOffset );
 
     /// <summary>
     /// Reads a <see cref="bool"/> at <paramref name="offset"/>.
@@ -77,7 +73,7 @@ public readonly struct RawRow( ExcelPage page, uint offset, uint row ) : IExcelR
     /// <param name="offset">Offset of the field inside the row.</param>
     /// <inheritdoc cref="ExcelPage.ReadBool(nuint)"/>
     public bool ReadBool( nuint offset ) =>
-        page.ReadBool( Offset + offset );
+        page.ReadBool( RowOffset + offset );
 
     /// <summary>
     /// Reads a <see cref="sbyte"/> at <paramref name="offset"/>.
@@ -85,7 +81,7 @@ public readonly struct RawRow( ExcelPage page, uint offset, uint row ) : IExcelR
     /// <param name="offset">Offset of the field inside the row.</param>
     /// <inheritdoc cref="ExcelPage.ReadInt8(nuint)"/>
     public sbyte ReadInt8( nuint offset ) =>
-        page.ReadInt8( Offset + offset );
+        page.ReadInt8( RowOffset + offset );
 
     /// <summary>
     /// Reads a <see cref="byte"/> at <paramref name="offset"/>.
@@ -93,7 +89,7 @@ public readonly struct RawRow( ExcelPage page, uint offset, uint row ) : IExcelR
     /// <param name="offset">Offset of the field inside the row.</param>
     /// <inheritdoc cref="ExcelPage.ReadUInt8(nuint)"/>
     public byte ReadUInt8( nuint offset ) =>
-        page.ReadUInt8( Offset + offset );
+        page.ReadUInt8( RowOffset + offset );
 
     /// <summary>
     /// Reads a <see cref="short"/> at <paramref name="offset"/>.
@@ -101,7 +97,7 @@ public readonly struct RawRow( ExcelPage page, uint offset, uint row ) : IExcelR
     /// <param name="offset">Offset of the field inside the row.</param>
     /// <inheritdoc cref="ExcelPage.ReadInt16(nuint)"/>
     public short ReadInt16( nuint offset ) =>
-        page.ReadInt16( Offset + offset );
+        page.ReadInt16( RowOffset + offset );
 
 
     /// <summary>
@@ -110,7 +106,7 @@ public readonly struct RawRow( ExcelPage page, uint offset, uint row ) : IExcelR
     /// <param name="offset">Offset of the field inside the row.</param>
     /// <inheritdoc cref="ExcelPage.ReadUInt16(nuint)"/>
     public ushort ReadUInt16( nuint offset ) =>
-        page.ReadUInt16( Offset + offset );
+        page.ReadUInt16( RowOffset + offset );
 
     /// <summary>
     /// Reads a <see cref="int"/> at <paramref name="offset"/>.
@@ -118,7 +114,7 @@ public readonly struct RawRow( ExcelPage page, uint offset, uint row ) : IExcelR
     /// <param name="offset">Offset of the field inside the row.</param>
     /// <inheritdoc cref="ExcelPage.ReadInt32(nuint)"/>
     public int ReadInt32( nuint offset ) =>
-        page.ReadInt32( Offset + offset );
+        page.ReadInt32( RowOffset + offset );
 
     /// <summary>
     /// Reads a <see cref="uint"/> at <paramref name="offset"/>.
@@ -126,7 +122,7 @@ public readonly struct RawRow( ExcelPage page, uint offset, uint row ) : IExcelR
     /// <param name="offset">Offset of the field inside the row.</param>
     /// <inheritdoc cref="ExcelPage.ReadUInt32(nuint)"/>
     public uint ReadUInt32( nuint offset ) =>
-        page.ReadUInt32( Offset + offset );
+        page.ReadUInt32( RowOffset + offset );
 
     /// <summary>
     /// Reads a <see cref="float"/> at <paramref name="offset"/>.
@@ -134,7 +130,7 @@ public readonly struct RawRow( ExcelPage page, uint offset, uint row ) : IExcelR
     /// <param name="offset">Offset of the field inside the row.</param>
     /// <inheritdoc cref="ExcelPage.ReadFloat32(nuint)"/>
     public float ReadFloat32( nuint offset ) =>
-        page.ReadFloat32( Offset + offset );
+        page.ReadFloat32( RowOffset + offset );
 
     /// <summary>
     /// Reads a <see cref="long"/> at <paramref name="offset"/>.
@@ -142,7 +138,7 @@ public readonly struct RawRow( ExcelPage page, uint offset, uint row ) : IExcelR
     /// <param name="offset">Offset of the field inside the row.</param>
     /// <inheritdoc cref="ExcelPage.ReadInt64(nuint)"/>
     public long ReadInt64( nuint offset ) =>
-        page.ReadInt64( Offset + offset );
+        page.ReadInt64( RowOffset + offset );
 
     /// <summary>
     /// Reads a <see cref="ulong"/> at <paramref name="offset"/>.
@@ -150,7 +146,7 @@ public readonly struct RawRow( ExcelPage page, uint offset, uint row ) : IExcelR
     /// <param name="offset">Offset of the field inside the row.</param>
     /// <inheritdoc cref="ExcelPage.ReadUInt64(nuint)"/>
     public ulong ReadUInt64( nuint offset ) =>
-        page.ReadUInt64( Offset + offset );
+        page.ReadUInt64( RowOffset + offset );
 
     /// <summary>
     /// Reads a <see cref="bool"/> at <paramref name="offset"/> at bit offset <paramref name="bit"/>.
@@ -159,7 +155,7 @@ public readonly struct RawRow( ExcelPage page, uint offset, uint row ) : IExcelR
     /// <param name="bit">Bit offset of the field inside the byte. (0 - 7)</param>
     /// <inheritdoc cref="ExcelPage.ReadPackedBool(nuint, byte)"/>
     public bool ReadPackedBool( nuint offset, byte bit ) =>
-        page.ReadPackedBool( Offset + offset, bit );
+        page.ReadPackedBool( RowOffset + offset, bit );
 
     /// <summary>
     /// Reads a <see cref="ReadOnlySeString"/> at <paramref name="columnIdx"/>.

--- a/src/Lumina/Excel/RawSubrow.cs
+++ b/src/Lumina/Excel/RawSubrow.cs
@@ -6,19 +6,17 @@ using System.Collections.Generic;
 namespace Lumina.Excel;
 
 /// <summary>
-/// An <see cref="IExcelSubrow{T}"/> type for explicitly reading data from an <see cref="ExcelPage"/>.
+/// An <see cref="IExcelSubrow{T}"/> type for explicitly reading data from an <see cref="Excel.ExcelPage"/>.
 /// </summary>
 /// <inheritdoc cref="RawRow"/>
 [Sheet]
 public readonly struct RawSubrow( ExcelPage page, uint offset, uint row, ushort subrow ) : IExcelSubrow<RawSubrow>
 {
-    /// <inheritdoc cref="RawRow.Page"/>
-    public ExcelPage Page => page;
+    /// <inheritdoc/>
+    public ExcelPage ExcelPage => page;
 
-    /// <summary>
-    /// Offset to the referenced row in the <see cref="Page"/>.
-    /// </summary>
-    public uint Offset => offset;
+    /// <inheritdoc/>
+    public uint RowOffset => offset;
 
     /// <inheritdoc/>
     public uint RowId => row;
@@ -64,51 +62,51 @@ public readonly struct RawSubrow( ExcelPage page, uint offset, uint row, ushort 
 
     /// <inheritdoc cref="RawRow.ReadString(nuint)"/>
     public ReadOnlySeString ReadString( nuint offset ) =>
-        page.ReadString( Offset + offset, Offset );
+        page.ReadString( RowOffset + offset, RowOffset );
 
     /// <inheritdoc cref="RawRow.ReadBool(nuint)"/>
     public bool ReadBool( nuint offset ) =>
-        page.ReadBool( Offset + offset );
+        page.ReadBool( RowOffset + offset );
 
     /// <inheritdoc cref="RawRow.ReadInt8(nuint)"/>
     public sbyte ReadInt8( nuint offset ) =>
-        page.ReadInt8( Offset + offset );
+        page.ReadInt8( RowOffset + offset );
 
     /// <inheritdoc cref="RawRow.ReadUInt8(nuint)"/>
     public byte ReadUInt8( nuint offset ) =>
-        page.ReadUInt8( Offset + offset );
+        page.ReadUInt8( RowOffset + offset );
 
     /// <inheritdoc cref="RawRow.ReadInt16(nuint)"/>
     public short ReadInt16( nuint offset ) =>
-        page.ReadInt16( Offset + offset );
+        page.ReadInt16( RowOffset + offset );
 
     /// <inheritdoc cref="RawRow.ReadUInt16(nuint)"/>
     public ushort ReadUInt16( nuint offset ) =>
-        page.ReadUInt16( Offset + offset );
+        page.ReadUInt16( RowOffset + offset );
 
     /// <inheritdoc cref="RawRow.ReadInt32(nuint)"/>
     public int ReadInt32( nuint offset ) =>
-        page.ReadInt32( Offset + offset );
+        page.ReadInt32( RowOffset + offset );
 
     /// <inheritdoc cref="RawRow.ReadUInt32(nuint)"/>
     public uint ReadUInt32( nuint offset ) =>
-        page.ReadUInt32( Offset + offset );
+        page.ReadUInt32( RowOffset + offset );
 
     /// <inheritdoc cref="RawRow.ReadFloat32(nuint)"/>
     public float ReadFloat32( nuint offset ) =>
-        page.ReadFloat32( Offset + offset );
+        page.ReadFloat32( RowOffset + offset );
 
     /// <inheritdoc cref="RawRow.ReadInt64(nuint)"/>
     public long ReadInt64( nuint offset ) =>
-        page.ReadInt64( Offset + offset );
+        page.ReadInt64( RowOffset + offset );
 
     /// <inheritdoc cref="RawRow.ReadUInt64(nuint)"/>
     public ulong ReadUInt64( nuint offset ) =>
-        page.ReadUInt64( Offset + offset );
+        page.ReadUInt64( RowOffset + offset );
 
     /// <inheritdoc cref="RawRow.ReadPackedBool(nuint, byte)"/>
     public bool ReadPackedBool( nuint offset, byte bit ) =>
-        page.ReadPackedBool( Offset + offset, bit );
+        page.ReadPackedBool( RowOffset + offset, bit );
 
     /// <inheritdoc cref="RawRow.ReadStringColumn(int)"/>
     public ReadOnlySeString ReadStringColumn( int columnIdx ) =>

--- a/src/Lumina/Extensions/BinaryReaderExtensions.cs
+++ b/src/Lumina/Extensions/BinaryReaderExtensions.cs
@@ -68,7 +68,7 @@ namespace Lumina.Extensions
         {
             var data = br.ReadBytes( Unsafe.SizeOf< T >() * count );
 
-            return MemoryMarshal.Cast< byte, T >( data );
+            return MemoryMarshal.Cast< byte, T >( data.AsSpan() );
         }
 
         /// <summary>

--- a/src/Lumina/Lumina.csproj
+++ b/src/Lumina/Lumina.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net10.0</TargetFrameworks>
         <LangVersion>latestmajor</LangVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>NotAdam</Authors>
@@ -28,8 +28,8 @@
 
     <ItemGroup>
         <PackageReference Include="BCnEncoder.Net" Version="2.2.1" />
-        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.7" />
-        <PackageReference Include="MinVer" Version="5.0.0">
+        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.0" />
+        <PackageReference Include="MinVer" Version="6.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
In https://github.com/NotAdam/Lumina.Excel/pull/11 we added `ExcelPage` and `RowOffset` properties to the generated sheet structs.
It would only make sense if we add those to the interfaces `IExcelRow<T>` and `IExcelSubrow<T>` too.

I had to rename the existing `Page` and `Offset` properties in `RawRow` and `RawSubrow` accordingly, which in turn also makes it much clearer what the offset is actually for.

Also updated:
- everything to .NET 10
- nuget dependencies
- Lumina.Example to use the new sheets system
- the CI workflow, but didn't touch the deprecated `actions/create-release@v1` action.

But I can also remove those commits again, I don't mind either way.