### PR TITLE
Rename ChineseTraditional2 to TraditionalChinese

### DIFF
--- a/src/Lumina/Data/Language.cs
+++ b/src/Lumina/Data/Language.cs
@@ -15,7 +15,7 @@ namespace Lumina.Data
         ChineseSimplified,
         ChineseTraditional,
         Korean,
-        ChineseTraditional2,
+        TraditionalChinese,
     }
 
     public class LanguageUtil
@@ -30,7 +30,7 @@ namespace Lumina.Data
             { Language.ChineseSimplified, "chs" },
             { Language.ChineseTraditional, "cht" },
             { Language.Korean, "ko" },
-            { Language.ChineseTraditional2, "tc" },
+            { Language.TraditionalChinese, "tc" },
         };
 
         public static string GetLanguageStr( Language lang )


### PR DESCRIPTION
- Aligns with the internal client-side code "tc" used for the Traditional Chinese server.
- And to eliminates confusion with the CN server's language definitions. The CN server defines ChineseSimplified (`chs`) and ChineseTraditional (`cht`). Although `cht` is currently unused in the CN server, it is reserved for that scope. The previous name `ChineseTraditional2` may lead to confusion.