### PR TITLE
Add TryGetValue to RowRef{T}, SubrowRef{T}

### DIFF
--- a/src/Lumina/Excel/RowRef{T}.cs
+++ b/src/Lumina/Excel/RowRef{T}.cs
@@ -52,7 +52,7 @@ public struct RowRef< T >( ExcelModule? module, uint rowId, Language? language =
     {
         var valueNullable = ValueNullable;
         row = valueNullable ?? default;
-        return valueNullable != null;
+        return valueNullable.HasValue;
     }
 
     /// <summary>

--- a/src/Lumina/Excel/RowRef{T}.cs
+++ b/src/Lumina/Excel/RowRef{T}.cs
@@ -44,6 +44,18 @@ public struct RowRef< T >( ExcelModule? module, uint rowId, Language? language =
     public readonly Language? Language => language ?? module?.Language;
 
     /// <summary>
+    /// Tries to get the referenced row as a specific row type.
+    /// </summary>
+    /// <param name="row">The output row object.</param>
+    /// <returns><see langword="true"/> if the type is valid, the row exists, and <paramref name="row"/> is written to, and <see langword="false"/> otherwise.</returns>
+    public bool TryGetValue( out T row )
+    {
+        var valueNullable = ValueNullable;
+        row = valueNullable ?? default;
+        return valueNullable != null;
+    }
+
+    /// <summary>
     /// Whether the <see cref="RowId"/> exists in the sheet.
     /// </summary>
     public bool IsValid => Sheet?.HasRow( RowId ) ?? false;

--- a/src/Lumina/Excel/SubrowRef{T}.cs
+++ b/src/Lumina/Excel/SubrowRef{T}.cs
@@ -43,6 +43,14 @@ public struct SubrowRef< T >( ExcelModule? module, uint rowId, Language? languag
     /// </remarks>
     public readonly Language? Language => language ?? module?.Language;
 
+    /// <inheritdoc cref="RowRef{T}.TryGetValue(out T)"/>
+    public bool TryGetValue( out SubrowCollection<T> row )
+    {
+        var valueNullable = ValueNullable;
+        row = valueNullable ?? default;
+        return valueNullable != null;
+    }
+
     /// <summary>
     /// Whether the <see cref="RowId"/> exists in the sheet.
     /// </summary>

--- a/src/Lumina/Excel/SubrowRef{T}.cs
+++ b/src/Lumina/Excel/SubrowRef{T}.cs
@@ -48,7 +48,7 @@ public struct SubrowRef< T >( ExcelModule? module, uint rowId, Language? languag
     {
         var valueNullable = ValueNullable;
         row = valueNullable ?? default;
-        return valueNullable != null;
+        return valueNullable.HasValue;
     }
 
     /// <summary>


### PR DESCRIPTION
Just for supporting the TryGet pattern in the typed RowRef/SubrowRef.
The untyped RowRef already has it.

CC: @WorkingRobot