### PR TITLE
Update MapRangeInstanceObject

### DIFF
--- a/src/Lumina/Data/Parsing/Layer/LayerCommon.cs
+++ b/src/Lumina/Data/Parsing/Layer/LayerCommon.cs
@@ -1106,7 +1106,10 @@ namespace Lumina.Data.Parsing.Layer
             public byte BGMPlayZoneInOnly;
             public byte LiftEnabled;
             public byte HousingEnabled;
-            private byte[] _padding01; //[2]
+            public byte LogFlyingHeightMaxErr;
+            private byte _padding01;
+            public byte MountsAndOrnamentsDisabled;
+            public byte LalafellOnly;
 
             public static MapRangeInstanceObject Read( LuminaBinaryReader br )
             {
@@ -1134,7 +1137,10 @@ namespace Lumina.Data.Parsing.Layer
                 ret.BGMPlayZoneInOnly = br.ReadByte();
                 ret.LiftEnabled = br.ReadByte();
                 ret.HousingEnabled = br.ReadByte();
-                ret._padding01 = br.ReadBytes( 2 );
+                ret.LogFlyingHeightMaxErr = br.ReadByte();
+                ret._padding01 = br.ReadByte();
+                ret.MountsAndOrnamentsDisabled = br.ReadByte();
+                ret.LalafellOnly = br.ReadByte();
 
                 return ret;
             }


### PR DESCRIPTION
I've tested the flags in game and added them to ClientStructs, then reversed them to the fields coming from the files, so here we are. Locally built and tested against some sample files too.

- `LogFlyingHeightMaxErr` is named after the ConfigOption LogFlyingHeightMaxErrDisp. If both are true, it prints LogMessage#846 "Your mount can fly no higher."  
  Could theoretically mean something different (like FlyingHeightLimited or so), but hey, someone can always rename it.
- `MountsAndOrnamentsDisabled` sets Status#1945 "Hoofing It - Unable to summon or ride mounts, or to equip fashion accessories." and dismounts/disables the ornament.
- `LalafellOnly` prints LogMessage#181 "Only Lalafells may enter this area." and blocks the character from entering (if not Lalafell).