### PR TITLE
Fix ScdFile#GetAudio for OGG files

### DIFF
--- a/src/Lumina.Tests/LuminaTests.cs
+++ b/src/Lumina.Tests/LuminaTests.cs
@@ -34,6 +34,5 @@ public class LuminaTests
         Assert.NotNull( file.GetSound( 0 ) );
         Assert.True( file.TrackDataCount > 0 );
         Assert.NotNull( file.GetTrack( 0 ) );
-
     }
 }

--- a/src/Lumina.Tests/LuminaTests.cs
+++ b/src/Lumina.Tests/LuminaTests.cs
@@ -1,3 +1,4 @@
+using Lumina.Data.Files;
 using Xunit;
 
 namespace Lumina.Tests;
@@ -17,5 +18,22 @@ public class LuminaTests
         Assert.Equal( category, parsed.Category );
         Assert.Equal( repo, parsed.Repository );
         Assert.Equal( hash, parsed.IndexHash );
+    }
+
+    [RequiresGameInstallationFact]
+    public void ScdFilesAreLoadedCorrectly()
+    {
+        var gameData = RequiresGameInstallationFact.CreateGameData();
+        var file = gameData.GetFile<ScdFile>( "music/ex1/bgm_ex1_alex01.scd" );
+
+        Assert.NotNull( file );
+        Assert.NotEmpty( file.Data );
+        Assert.True( file.AudioDataCount > 0 );
+        Assert.NotNull( file.GetAudio( 0 ) );
+        Assert.True( file.SoundDataCount > 0 );
+        Assert.NotNull( file.GetSound( 0 ) );
+        Assert.True( file.TrackDataCount > 0 );
+        Assert.NotNull( file.GetTrack( 0 ) );
+
     }
 }

--- a/src/Lumina/Data/Files/ScdFile.cs
+++ b/src/Lumina/Data/Files/ScdFile.cs
@@ -514,7 +514,7 @@ namespace Lumina.Data.Files
                     audio.AudioDataHeader = oggSeekTableHeader;
                     audio.SeekTable = Reader.ReadUInt32Array( (int)( oggSeekTableHeader.SeekTableSize / 4 ) );
 
-                    Reader.Position = subInfoStartPos + audioBasicDesc.SubInfoSize;
+                    Reader.Position = subInfoStartPos + audioBasicDesc.SubInfoSize - oggSeekTableHeader.OggHeaderSize;
 
                     var oggFile = new byte[ oggSeekTableHeader.OggHeaderSize + audioBasicDesc.Size ];
                     Array.Copy( Reader.ReadBytes( (int)oggSeekTableHeader.OggHeaderSize ), oggFile, oggSeekTableHeader.OggHeaderSize );


### PR DESCRIPTION
Fix for #116, based on what I found to work when looking into it.

In addition to the test included in the PR, I ran the change against all `.scd` files in [this rl2 pathlist](https://rl2.perchbird.dev/download/CurrentPathList.zip) via the following test code
```C#
    [RequiresGameInstallationFact]
    public void ScdFilesAreLoadedCorrectlyAll()
    {
        var gameData = RequiresGameInstallationFact.CreateGameData();
        var filePaths = File.ReadAllLines(@"C:\Users\USER\Documents\scdFiles.txt");
    
        Assert.All(
            filePaths.Select(p => {
                try
                {
                    return gameData.GetFile<ScdFile>(p);
                }
                catch
                {
                    return null;
                }
            }).Where(p => p is not null),
            file => {
                Assert.NotEmpty( file.Data );
                for (var i = 0; i < file.AudioDataCount; i++)
                {
                    Assert.NotNull(file.GetAudio(i));
                }
            }
        );
    }
```